### PR TITLE
Allow increment/decrement to pass to super if no counter is defined 

### DIFF
--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -46,6 +46,21 @@ class CustomRoster < Roster
   counter :special # New
 end
 
+class MethodRoster
+  def increment(attribute, by=1)
+    42
+  end
+  
+  def initialize(id=1) @id = id end
+  def id; @id; end
+end
+
+class CustomMethodRoster < MethodRoster
+  include Redis::Objects
+  
+  attr_accessor :counter
+  counter :basic
+end
 
 describe Redis::Objects do
   before do
@@ -747,5 +762,15 @@ describe Redis::Objects do
 
   it "should handle new subclass objects" do
     @custom_roster.special.increment.should == 1
+  end
+  
+  it "should allow passing of increment/decrement to super class" do
+    @custom_method_roster = CustomMethodRoster.new
+    @custom_method_roster.counter.should.be.nil
+    
+    @custom_method_roster.increment(:counter).should == 42
+    
+    @custom_method_roster.increment(:basic).should == 1
+    @custom_method_roster.basic.should.be.kind_of(Redis::Counter)
   end
 end


### PR DESCRIPTION
This is needed as otherwise the instance methods would override ActiveRecord's and result in increment/decrement being called on a eg. Fixnum.
