### PR TITLE
Single file to load all classes in standalone mode

### DIFF
--- a/lib/redis/standalone.rb
+++ b/lib/redis/standalone.rb
@@ -1,0 +1,7 @@
+require "redis/counter"
+require "redis/hash_key"
+require "redis/list"
+require "redis/lock"
+require "redis/set"
+require "redis/sorted_set"
+require "redis/value"


### PR DESCRIPTION
Hey,

in my app I'm using redis-objects in "standalone" mode and this patch allows me to do this:
    gem "redis-objects", :require => "redis/standalone"
to load all classes.
