### PR TITLE
Use of Redis.current

### DIFF
--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -4,7 +4,7 @@ class Redis
     def initialize(key, *args)
       @key     = key.is_a?(Array) ? key.flatten.join(':') : key
       @options = args.last.is_a?(Hash) ? args.pop : {}
-      @redis   = args.first || $redis
+      @redis   = args.first || $redis || Redis.current
     end
     
     alias :inspect :to_s  # Ruby 1.9.2

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -1,6 +1,7 @@
 # Redis::Objects - Lightweight object layer around redis-rb
 # See README.rdoc for usage and approach.
 require 'redis'
+
 class Redis
   #
   # Redis::Objects enables high-performance atomic operations in your app
@@ -51,7 +52,7 @@ class Redis
     class << self
       def redis=(conn) @redis = conn end
       def redis
-        @redis ||= $redis || raise(NotConnected, "Redis::Objects.redis not set to a Redis.new connection")
+        @redis ||= $redis || Redis.current || raise(NotConnected, "Redis::Objects.redis not set to a Redis.new connection")
       end
 
       def included(klass)
@@ -75,7 +76,11 @@ class Redis
     # Class methods that appear in your class when you include Redis::Objects.
     module ClassMethods
       attr_accessor :redis, :redis_objects
-
+      
+      def redis
+        @redis ||= Objects.redis
+      end
+      
       # Set the Redis redis_prefix to use. Defaults to model_name
       def redis_prefix=(redis_prefix) @redis_prefix = redis_prefix end
       def redis_prefix(klass = self) #:nodoc:
@@ -108,7 +113,10 @@ class Redis
 
     # Instance methods that appear in your class when you include Redis::Objects.
     module InstanceMethods
-      def redis() self.class.redis end
+      def redis
+        self.class.redis
+      end
+      
       def redis_field_key(name) #:nodoc:
         klass = self.class.first_ancestor_with(name)
         if key = klass.redis_objects[name.to_sym][:key]

--- a/spec/redis_namespace_compat_spec.rb
+++ b/spec/redis_namespace_compat_spec.rb
@@ -1,14 +1,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 require 'redis/objects'
-Redis::Objects.redis = $redis
 
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../../redis-namespace/lib')
 require 'redis/namespace'
 
 describe 'Redis::Namespace compat' do
   it "tests the compatibility of Hash and ::Hash conflicts" do
-    ns = Redis::Namespace.new("resque", :redis => $redis)
+    ns = Redis::Namespace.new("resque")
     ns.instance_eval { rem_namespace({"resque:x" => nil}) }.should == {"x"=>nil}
     class Foo
       include Redis::Objects

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -2,7 +2,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 require 'redis/objects'
-Redis::Objects.redis = $redis
 
 class Roster
   include Redis::Objects

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,6 @@ $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 require 'bacon'
 Bacon.summary_at_exit
 
-$redis = Redis.new(:host => ENV['REDIS_HOST'], :port => ENV['REDIS_PORT'])
-
 UNIONSTORE_KEY = 'test:unionstore'
 INTERSTORE_KEY = 'test:interstore'
 DIFFSTORE_KEY  = 'test:diffstore'


### PR DESCRIPTION
Hi,

I've modified redis-object to use the new standard way to grab a connection to Redis:
https://github.com/ezmobius/redis-rb/commit/23ed5974e96e89f4ef691139a9380a9d08e9cec6

This change is totaly backward compatible with the $redis global variable.

Regards.
