### PR TITLE
Ignore redis-namespace tests if it's not installed

### DIFF
--- a/spec/redis_namespace_compat_spec.rb
+++ b/spec/redis_namespace_compat_spec.rb
@@ -4,15 +4,18 @@ require 'redis/objects'
 Redis::Objects.redis = $redis
 
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../../redis-namespace/lib')
-require 'redis/namespace'
+begin
+  require 'redis/namespace'
 
-describe 'Redis::Namespace compat' do
-  it "tests the compatibility of Hash and ::Hash conflicts" do
-    ns = Redis::Namespace.new("resque", :redis => $redis)
-    ns.instance_eval { rem_namespace({"resque:x" => nil}) }.should == {"x"=>nil}
-    class Foo
-      include Redis::Objects
+  describe 'Redis::Namespace compat' do
+    it "tests the compatibility of Hash and ::Hash conflicts" do
+      ns = Redis::Namespace.new("resque", :redis => $redis)
+      ns.instance_eval { rem_namespace({"resque:x" => nil}) }.should == {"x"=>nil}
+      class Foo
+        include Redis::Objects
+      end
+      ns.instance_eval { rem_namespace({"resque:x" => nil}) }.should == {"x"=>nil}
     end
-    ns.instance_eval { rem_namespace({"resque:x" => nil}) }.should == {"x"=>nil}
   end
+rescue LoadError
 end


### PR DESCRIPTION
The tests fail if redis-namespace is not installed. Since it's not a dependency, just skip the tastes if the require fails.
