### PR TITLE
Modify objects to play nicely with Redis#pipelined

### DIFF
--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -70,7 +70,7 @@ class Redis
 
     # Retrieve the entire hash.  Redis: HGETALL
     def all
-      h = redis.hgetall(key)
+      h = redis.hgetall(key) || {}
       h.each { |k,v| h[k] = from_redis(v, options[:marshal_keys][k]) }
       h
     end


### PR DESCRIPTION
When under Redis#pipelined, some calls return nil values, which then cause errors in Redis objects.  In particular, HashKeys#all gives a `NoMethodError` on nil.  I've modified that method to properly handle the nil case, but there could be other places in which the change is necessary.

Please ignore this pull request if Redis objects do not support pipelining, or you feel that the Redis driver itself should return dummy, non-nil values.
