### PR TITLE
Add persist support, fix bug in ttl

### DIFF
--- a/lib/redis/helpers/core_commands.rb
+++ b/lib/redis/helpers/core_commands.rb
@@ -38,6 +38,10 @@ class Redis
         redis.expire key, unixtime
       end
 
+      def persist
+        redis.persist key
+      end
+
       def ttl
         redis.ttl(@key)
       end

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -142,6 +142,26 @@ describe Redis::Objects do
     @roster.contact_information.size.should == 2
   end
 
+  it 'should be able to expire keys and then persist them' do
+    # on a hash_key
+    @roster.contact_information['Jenny_Phone'] = '8675309'
+    @roster.contact_information.expire 30
+    @roster.contact_information.ttl.should > -1
+    @roster.contact_information.ttl.should <= 30
+    @roster.contact_information.persist
+    @roster.contact_information.ttl.should == -1
+    @roster.contact_information['Jenny_Phone'].should == '8675309'
+
+    # on a value
+    @roster.my_rank = 42
+    @roster.my_rank.expire 30
+    @roster.my_rank.ttl.should > -1
+    @roster.my_rank.ttl.should <= 30
+    @roster.my_rank.persist
+    @roster.my_rank.ttl.should == -1
+    @roster.my_rank.to_i.should == 42
+  end
+
   it "should be marshalling hash keys" do
     @roster.contact_information['updated_at'] = Time.now
     @roster.contact_information['updated_at'].class.should == Time


### PR DESCRIPTION
- added support for `persist` on all redis-objects
- added test coverage for `expire`, `ttl`, and `persist`
- fixed bug in ttl, which sends missing method `seconds` to the return of `redis.ttl(key)`, an Integer.
