### PR TITLE
Fix interstore/unionstore

### DIFF
--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -226,7 +226,7 @@ class Redis
     # Calculate the union and store it in Redis as +name+. Returns the number
     # of elements in the stored union. Redis: SUNIONSTORE
     def unionstore(name, *sets)
-      redis.zunionstore(name, key, *keys_from_objects(sets))
+      redis.zunionstore(name, keys_from_objects([self] + sets))
     end
 
     # Return the difference vs another set.  Can pass it either another set


### PR DESCRIPTION
Hey Nate, 

the redis.rb API for zinterstore/zunionstore seems to have changed at some point, so I changed #interstore/#unionstore to reflect that.

Also keep in mind that zinter/zunion were removed from redis, so the #intersection/#union methods only work with older redis/redis.rb versions. antirez's proposed fix is here: http://code.google.com/p/redis/issues/detail?id=328. I would have implemented it but I have no use for it right now, and no time, also.

Thanks for redis-objects. It came in handy. :)

David
