### PR TITLE
Redis::Objects.redis and Redis::Objects.redis=(conn) implies that the ca...

### DIFF
--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -4,7 +4,7 @@ class Redis
     def initialize(key, *args)
       @key     = key.is_a?(Array) ? key.flatten.join(':') : key
       @options = args.last.is_a?(Hash) ? args.pop : {}
-      @redis   = args.first || $redis || Redis.current
+      @redis   = args.first || Objects.redis
     end
 
     alias :inspect :to_s  # Ruby 1.9.2


### PR DESCRIPTION
...nonical place to set a redis connection global to the library is there.  See lines 53 and 54

https://github.com/nateware/redis-objects/blob/master/lib/redis/objects.rb#L53

https://github.com/nateware/redis-objects/blob/master/lib/redis/objects.rb#L54

We had two separated redis connections (resque, and redis objects) in http://www.hark.com/, and when we added a third separated connection to different redis server the redis objects library inappropriately attached itself there via $redis || Redis.current in Redis::BaseObject#initializer
