### PR TITLE
Changing .score method on SortedSet to return nil for invalid members (Redis default functionality)

### DIFF
--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -41,7 +41,7 @@ class Redis
         when -1 then nil  # Ruby does this (a bit weird)
         end
       else
-        score(index)
+        result = score(index) || 0 # handles a nil score
       end
     end
     alias_method :slice, :[]
@@ -50,7 +50,9 @@ class Redis
     # specified element does not exist in the sorted set, or the key does not exist
     # at all, nil is returned. Redis: ZSCORE.
     def score(member)
-      redis.zscore(key, to_redis(member)).to_f
+      result = redis.zscore(key, to_redis(member))
+
+      result.to_f unless result.nil?
     end
 
     # Return the rank of the member in the sorted set, with scores ordered from

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -781,6 +781,7 @@ describe Redis::SortedSet do
     @set['b'] = 5
     @set['b'] = 6
     @set.score('b').should == 6
+    @set.score('f').should == nil
     @set.delete('c')
     @set.to_s.should == 'a, b'
     @set.should == ['a','b']


### PR DESCRIPTION
This patch prevents redis-objects from swallowing the redis return value for ZSET SCORE which currently casts nil to a float which returns 0.0 instead of nil. 
