### PR TITLE
HashKey#bulk_values for fetching values in the same order than the given keys

### DIFF
--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -135,6 +135,13 @@ class Redis
       hsh
     end
 
+    # Get values in bulk, takes an array of keys as arguments.
+    # Values are returned in a collection in the same order than their keys in *keys Redis: HMGET
+    def bulk_values(*keys)
+      res = redis.hmget(key, *keys.flatten)
+      keys.inject([]){|collection, k| collection << from_redis(res.shift)}
+    end
+
     # Increment value by integer at field. Redis: HINCRBY
     def incrby(field, val = 1)
       ret = redis.hincrby(key, field, val)


### PR DESCRIPTION
Hello,

thank you very much for this wonderful gem :-)

I have just added a bulk_values method in HashKey model. Useful for retrieving HashKey values in bulk in a collection in the same order than their keys.

e.g: If you want to fetch some HashKey values which keys are stored in a sorted list, this new method will help you. It will return a collection of values in the same ordered as the given keys.

I hope that you find this method kind of useful.
