### PR TITLE
BUGFIX Expireat function

### DIFF
--- a/lib/redis/helpers/core_commands.rb
+++ b/lib/redis/helpers/core_commands.rb
@@ -35,7 +35,7 @@ class Redis
       end
 
       def expireat(unixtime)
-        redis.expire key, unixtime
+        redis.expireat key, unixtime
       end
 
       def persist


### PR DESCRIPTION
Redis::Objects were forwarding #expireat to #expire. Corrected the typo.
