### PR TITLE
Fix counter rewinding with nondefault by value

### DIFF
--- a/lib/redis/counter.rb
+++ b/lib/redis/counter.rb
@@ -52,7 +52,7 @@ class Redis
     # method is aliased as incr() for brevity.
     def increment(by=1, &block)
       val = redis.incrby(key, by).to_i
-      block_given? ? rewindable_block(:decrement, val, &block) : val
+      block_given? ? rewindable_block(:decrement, by, val, &block) : val
     end
     alias_method :incr, :increment
 
@@ -63,7 +63,7 @@ class Redis
     # method is aliased as incr() for brevity.
     def decrement(by=1, &block)
       val = redis.decrby(key, by).to_i
-      block_given? ? rewindable_block(:increment, val, &block) : val
+      block_given? ? rewindable_block(:increment, by, val, &block) : val
     end
     alias_method :decr, :decrement
 
@@ -85,16 +85,16 @@ class Redis
     private
 
     # Implements atomic increment/decrement blocks
-    def rewindable_block(rewind, value, &block)
+    def rewindable_block(rewind, by, value, &block)
       raise ArgumentError, "Missing block to rewindable_block somehow" unless block_given?
       ret = nil
       begin
         ret = yield value
       rescue
-        send(rewind)
+        send(rewind, by)
         raise
       end
-      send(rewind) if ret.nil?
+      send(rewind, by) if ret.nil?
       ret
     end
   end

--- a/lib/redis/objects/counters.rb
+++ b/lib/redis/objects/counters.rb
@@ -60,7 +60,7 @@ class Redis
           verify_counter_defined!(name, id)
           initialize_counter!(name, id)
           value = redis.incrby(redis_field_key(name, id), by).to_i
-          block_given? ? rewindable_block(:decrement_counter, name, id, value, &block) : value
+          block_given? ? rewindable_block(:decrement_counter, name, id, by, value, &block) : value
         end
 
         # Decrement a counter with the specified name and id.  Accepts a block
@@ -71,7 +71,7 @@ class Redis
           verify_counter_defined!(name, id)
           initialize_counter!(name, id)
           value = redis.decrby(redis_field_key(name, id), by).to_i
-          block_given? ? rewindable_block(:increment_counter, name, id, value, &block) : value
+          block_given? ? rewindable_block(:increment_counter, name, id, by, value, &block) : value
         end
 
         # Reset a counter to its starting value.
@@ -111,17 +111,17 @@ class Redis
         end
 
         # Implements increment/decrement blocks on a class level
-        def rewindable_block(rewind, name, id, value, &block) #:nodoc:
+        def rewindable_block(rewind, name, id, by, value, &block) #:nodoc:
           # Unfortunately this is almost exactly duplicated from Redis::Counter
           raise ArgumentError, "Missing block to rewindable_block somehow" unless block_given?
           ret = nil
           begin
             ret = yield value
           rescue
-            send(rewind, name, id)
+            send(rewind, name, id, by)
             raise
           end
-          send(rewind, name, id) if ret.nil?
+          send(rewind, name, id, by) if ret.nil?
           ret
         end
       end

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -261,9 +261,24 @@ describe Redis::Objects do
       nil  # should rewind
     end
     @roster.available_slots.should == 8
+
+    @roster.available_slots.should == 8
+    @roster.available_slots.decr(4) do |cnt|
+      @roster.available_slots.should == 4
+      nil  # should rewind
+    end
+    @roster.available_slots.should == 8
     
     @roster.available_slots.should == 8
     @roster.available_slots.incr do |cnt|
+      if 1 == 2  # should rewind
+        true
+      end
+    end
+    @roster.available_slots.should == 8
+
+    @roster.available_slots.should == 8
+    @roster.available_slots.incr(5) do |cnt|
       if 1 == 2  # should rewind
         true
       end
@@ -323,7 +338,22 @@ describe Redis::Objects do
     Roster.get_counter(:available_slots, @roster.id).should == 8
 
     Roster.get_counter(:available_slots, @roster.id).should == 8
+    Roster.decrement_counter(:available_slots, @roster.id, 4) do |cnt|
+      Roster.get_counter(:available_slots, @roster.id).should == 4
+      nil  # should rewind
+    end
+    Roster.get_counter(:available_slots, @roster.id).should == 8
+
+    Roster.get_counter(:available_slots, @roster.id).should == 8
     Roster.increment_counter(:available_slots, @roster.id) do |cnt|
+      if 1 == 2  # should rewind
+        true
+      end
+    end
+    Roster.get_counter(:available_slots, @roster.id).should == 8
+
+    Roster.get_counter(:available_slots, @roster.id).should == 8
+    Roster.increment_counter(:available_slots, @roster.id, 4) do |cnt|
       if 1 == 2  # should rewind
         true
       end


### PR DESCRIPTION
Addresses #36

Description:
- When a nondefault `by` is used for counter increment/decrement with blocks, the rewind doesn't work correcly.

Example:

``` irb
irb(main):001:0> require 'redis/counter'
=> true
irb(main):002:0> r = Redis::Counter.new(:foo)
=> #<Redis::Counter:0x007ff743551fa8>
irb(main):003:0> r.reset(5)
=> true
irb(main):004:0> r.increment(5) { nil }
=> nil
irb(main):005:0> r.value
=> 9
irb(main):006:0> "that should be 5..."
```

Changes:
- fixes the issue for `increment`/`decrement` as well as `increment_counter`/`decrement_counter` by passing `by` to `rewindable_block`
- Adds test cases for the methods above with a nondefault `by`

Thanks for looking over this!
