### PR TITLE
On a list the marshaling was not being respected when Insert at a specific index was used

### DIFF
--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -88,7 +88,7 @@ class Redis
 
     # Same functionality as Ruby arrays.
     def []=(index, value)
-      redis.lset(key, index, value)
+      redis.lset(key, index, to_redis(value))
     end
 
     # Delete the element(s) from the list that match name. If count is specified,


### PR DESCRIPTION
For example: 

``` ruby
@list = Redis::List.new
@list << {a: 1}
@list[0] = @list[0].tap{|list| list[:a] = 2}
@list[0].should == {a: 2} #FAILS
```

This is now passing, I also fixed a spec that interpreted the redis sort command incorrectly and was therefore failing. (At least I interpret the documentation differently)
