### PR TITLE
Add maxlength support for sorted sets

### DIFF
--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -26,6 +26,16 @@ class Redis
     # the score, since the member is the unique item (not the score).
     def add(member, score)
       redis.zadd(key, score, to_redis(member))
+
+      if ( maxlength = options[:maxlength] ) &&
+         ( (surplus = (redis.zcard(key) - maxlength)) > 0 )
+        members = if options[:pop_highest_score]
+                    redis.zrevrange(key, 0, surplus - 1)
+                  else
+                    redis.zrange(key, 0, surplus - 1)
+                  end
+        redis.zrem(key, members)
+      end
     end
 
     # Same functionality as Ruby arrays.  If a single number is given, return

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -892,4 +892,44 @@ describe Redis::SortedSet do
     @set_2.clear
     @set_3.clear
   end
+
+  describe "as a bounded sorted set" do
+    before do
+      @high_set = Redis::SortedSet.new('spec/bounded_sorted_set',
+                                       maxlength: 10)
+      @low_set  = Redis::SortedSet.new('spec/bounded_low_sorted_set',
+                                       maxlength: 10,
+                                       pop_highest_score: true)
+      1.upto(10) do |i|
+        @high_set[i.chr] = i
+        @low_set.add(i.chr, i)
+      end
+
+      # Make sure that adding < maxlength doesn't mess up.
+      1.upto(10) do |i|
+        @high_set[i.chr].should == i.to_f
+        @low_set[i.chr].should == i.to_f
+      end
+    end
+
+    after do
+      @high_set.clear
+      @low_set.clear
+    end
+
+    it "should push the element with the lowest score out of the set" do
+      @high_set[11.chr] = 11.to_f
+      @high_set.last.should == 11.chr
+      @high_set.first.should == 2.chr
+      @high_set.length.should == 10
+    end
+
+    it "should push the element with the highest score out of the set" do
+      @low_set[0.chr] = 0.to_f
+      @low_set.last.should == 9.chr
+      @low_set.first.should == 0.chr
+      @low_set.length.should == 10
+    end
+  end
+
 end


### PR DESCRIPTION
Similar to lists, add `maxlength` support to sorted sets.
An additional option `pop_highest_scores` determines whether to pop highest or lowest score elements. The default is to pop lowest score elements.
