### PR TITLE
Add support for pushing multiple values into a list.

### DIFF
--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -20,15 +20,15 @@ class Redis
       push(value)
       self  # for << 'a' << 'b'
     end
-	
+
     # Add a member before or after pivot in the list. Redis: LINSERT
     def insert(where,pivot,value)
       redis.linsert(key,where,to_redis(pivot),to_redis(value))
     end
 
     # Add a member to the end of the list. Redis: RPUSH
-    def push(value)
-      redis.rpush(key, to_redis(value))
+    def push(*values)
+      redis.rpush(key, values.map {|v| to_redis(v) })
       redis.ltrim(key, -options[:maxlength], -1) if options[:maxlength]
     end
 
@@ -132,16 +132,16 @@ class Redis
       redis.llen(key)
     end
     alias_method :size, :length
-   
+
     # Returns true if there are no elements in the list. Redis: LLEN == 0
     def empty?
       length == 0
     end
- 
+
     def ==(x)
       values == x
     end
-    
+
     def to_s
       values.join(', ')
     end

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -504,30 +504,33 @@ describe Redis::Objects do
     @roster.player_stats.size.should == 4
     @roster.player_stats.should == ['a','c','f','j']
     @roster.player_stats.get.should == ['a','c','f','j']
+    @roster.player_stats.push *['h','i']
+    @roster.player_stats.should == ['a','c','f','j','h','i']
+    @roster.player_stats.get.should == ['a','c','f','j','h','i']
 
     i = -1
     @roster.player_stats.each do |st|
       st.should == @roster.player_stats[i += 1]
     end
-    @roster.player_stats.should == ['a','c','f','j']
-    @roster.player_stats.get.should == ['a','c','f','j']
+    @roster.player_stats.should == ['a','c','f','j','h','i']
+    @roster.player_stats.get.should == ['a','c','f','j','h','i']
 
     @roster.player_stats.each_with_index do |st,i|
       st.should == @roster.player_stats[i]
     end
-    @roster.player_stats.should == ['a','c','f','j']
-    @roster.player_stats.get.should == ['a','c','f','j']
+    @roster.player_stats.should == ['a','c','f','j','h','i']
+    @roster.player_stats.get.should == ['a','c','f','j','h','i']
 
     coll = @roster.player_stats.collect{|st| st}
-    coll.should == ['a','c','f','j']
-    @roster.player_stats.should == ['a','c','f','j']
-    @roster.player_stats.get.should == ['a','c','f','j']
+    coll.should == ['a','c','f','j','h','i']
+    @roster.player_stats.should == ['a','c','f','j','h','i']
+    @roster.player_stats.get.should == ['a','c','f','j','h','i']
 
     @roster.player_stats << 'a'
     coll = @roster.player_stats.select{|st| st == 'a'}
     coll.should == ['a','a']
-    @roster.player_stats.should == ['a','c','f','j','a']
-    @roster.player_stats.get.should == ['a','c','f','j','a']
+    @roster.player_stats.should == ['a','c','f','j','h','i','a']
+    @roster.player_stats.get.should == ['a','c','f','j','h','i','a']
   end
 
   it "should handle sets of simple values" do


### PR DESCRIPTION
Ruby allows you to push multiple values into an array via:

``` ruby
array = []
values = [1,2,3]
array.push *values # => [1, 2, 3]
```

Redis also supports this with [`LPUSH`](http://redis.io/commands/lpush) and [`RPUSH`](http://redis.io/commands/rpush) as used here. But `redis-objects` has lacked support. This adds it.

Sorry for all the removals of whitespace. Sublime is set up to do that automatically on any file I save. I can fix it if it's an issue.
