### PR TITLE
HashKey#fetch behaves more similarly to native ruby (refs #118)

### DIFF
--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -30,7 +30,7 @@ class Redis
 
     # Gets the value of a field
     def [](field)
-      fetch(field)
+      hget(field)
     end
 
     # Redis: HSET
@@ -39,7 +39,7 @@ class Redis
     end
 
     # Redis: HGET
-    def fetch(field)
+    def hget(field)
       from_redis redis.hget(key, field), options[:marshal_keys][field]
     end
 
@@ -54,6 +54,15 @@ class Redis
     # Delete field. Redis: HDEL
     def delete(field)
       redis.hdel(key, field)
+    end
+
+    def fetch field, *args, &block
+      value = hget(field)
+      default = args[0]
+
+      return value if value || (!default && !block_given?)
+
+      block_given? ? block.call(field) : default
     end
 
     # Return all the keys of the hash. Redis: HKEYS

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -603,6 +603,18 @@ describe Redis::HashKey do
     end
   end
 
+  it "should fetch default values" do
+    @hash['abc'] = "123"
+
+    value = @hash.fetch('missing_key','default_value')
+    block = @hash.fetch("missing_key") {|key| "oops: #{key}" }
+    no_error = @hash.fetch("abc") rescue "error"
+
+    no_error.should == "123"
+    value.should == "default_value"
+    block.should == "oops: missing_key"
+  end
+
   after do
     @hash.clear
   end


### PR DESCRIPTION
I've renamed the current fetch method to hget, and replaced any calls to the current fetch to hget.

I've made the new fetch accept additional arguments.  Either a default value, or a block.  To be more in line with Ruby.  

Otherwise it will behave like the current fetch method.

I've included some specs.
