### PR TITLE
noop if you try to add an empty array to a set

### DIFF
--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -23,7 +23,7 @@ class Redis
     # Add the specified value to the set only if it does not exist already.
     # Redis: SADD
     def add(value)
-      redis.sadd(key, to_redis(value))
+      redis.sadd(key, to_redis(value)) if value.nil? || !Array(value).empty?
     end
 
     # Remove and return a random member.  Redis: SPOP

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -677,6 +677,17 @@ describe Redis::Set do
     @set.sort.should == ['a','b','c']
     @set.delete_if{|m| m == 'c'}
     @set.sort.should == ['a','b']
+
+    @set << nil
+    @set.include?("").should.be.true
+  end
+
+  it "should handle empty array adds" do
+    should.not.raise(Redis::CommandError) { @set.add([]) }
+    @set.should.be.empty
+
+    should.not.raise(Redis::CommandError) { @set << [] }
+    @set.should.be.empty
   end
 
   it "should handle set intersections, unions, and diffs" do


### PR DESCRIPTION
In my opinion, this should work:

```
foo = Redis::Set.new("foo")
foo << []
```

Currently it throws a Redis::CommandError

Also, added a test to make sure that adding nil to a set still adds an
empty element to the set

This is a fix for #121
