### PR TITLE
fix TypeError in SortedSet

### DIFF
--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -103,7 +103,7 @@ class Redis
     # Return a range of values from +start_index+ to +end_index+ in reverse order. Redis: ZREVRANGE
     def revrange(start_index, end_index, options={})
       if options[:withscores] || options[:with_scores]
-        redis.zrevrange(key, start_index, end_index, :with_scores => true).map{|v| unmarshal(v) }
+        redis.zrevrange(key, start_index, end_index, :with_scores => true).map{|v,s| [unmarshal(v), s] }
       else
         redis.zrevrange(key, start_index, end_index).map{|v| unmarshal(v) }
       end


### PR DESCRIPTION
recently a test case failed in my app with the following error message:

```
TypeError: instance of IO needed
```

after investigation, I've found that SortedSet#members takes the result of SortedSet#range, and tries map it with unmarshal. however the result from `#range` has already been unmarshaled.

the input of unmarshal requires to be an IO instance like StringIO, thus triggers this issue.
