### PR TITLE
add :default option to Counter

### DIFF
--- a/lib/redis/counter.rb
+++ b/lib/redis/counter.rb
@@ -15,7 +15,7 @@ class Redis
     attr_reader :key, :options
     def initialize(key, *args)
       super(key, *args)
-      @options[:start] ||= 0
+      @options[:start] ||= @options[:default] || 0
       raise ArgumentError, "Marshalling redis counters does not make sense" if @options[:marshal]
       redis.setnx(key, @options[:start]) unless @options[:start] == 0 || @options[:init] === false
     end


### PR DESCRIPTION
in `Value`, there is an option `:default` which allows us to set up a
default value for that key, but in Counter, the equivalent option
is `:start`. maybe it would be better to introduce an :default option
for `Counter`?

regards.
