### PR TITLE
Redis::Set#randmember method accept count as optional parameter

### DIFF
--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -30,8 +30,8 @@ class Redis
     end
 
     # return a random member.  Redis: SRANDMEMBER
-    def randmember
-      unmarshal redis.srandmember(key)
+    def randmember(count = nil)
+      unmarshal redis.srandmember(key, count)
     end
 
     # Adds the specified values to the set. Only works on redis > 2.4


### PR DESCRIPTION
The native redis method `randmember` for sets allows the optional parameter `count`.
This PR adds this param to `Redis::Set#randmember` method.
