### PR TITLE
Support connection_pool useage via a proxy object

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,17 @@ Add it to your Gemfile as:
 gem 'redis-objects'
 ~~~
 
-Redis::Objects needs a handle created by `Redis.new`. The recommended approach
-is to set `Redis.current` to point to your server, which Redis::Objects will
-pick up automatically.
+Redis::Objects needs a handle created by `Redis.new` or a [ConnectionPool](https://github.com/mperham/connection_pool):
 
+The recommended approach is to use a `ConnectionPool` since this guarantees that most timeouts in the `redis` client
+do not pollute your existing connection. However, you need to make sure that both `:timeout` and `:size` are set appropriately
+in a multithreaded environment.
+~~~ruby
+require 'connection_pool'
+Redis::Objects.redis = ConnectionPool.new(size: 5, timeout: 5) { Redis.new(:host => '127.0.0.1', :port => 6379) }
+~~~
+
+Redis::Objects can also default to `Redis.current` if `Redis::Objects.redis` is not set.
 ~~~ruby
 Redis.current = Redis.new(:host => '127.0.0.1', :port => 6379)
 ~~~
@@ -64,6 +71,7 @@ class Post
   include Redis::Objects
 end
 
+# you can also use a ConnectionPool here as well
 User.redis = Redis.new(:host => '1.2.3.4')
 Post.redis = Redis.new(:host => '5.6.7.8')
 ~~~

--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -4,7 +4,7 @@ class Redis
     def initialize(key, *args)
       @key     = key.is_a?(Array) ? key.flatten.join(':') : key
       @options = args.last.is_a?(Hash) ? args.pop : {}
-      @myredis = args.first
+      @myredis = Objects::ConnectionPoolProxy.proxy_if_needed(args.first)
     end
 
     # Dynamically query the handle to enable resetting midstream

--- a/lib/redis/objects/connection_pool_proxy.rb
+++ b/lib/redis/objects/connection_pool_proxy.rb
@@ -1,0 +1,30 @@
+class Redis
+  module Objects
+    class ConnectionPoolProxy
+      def initialize(pool)
+        raise ArgumentError "Should only proxy ConnectionPool!" unless self.class.should_proxy?(pool)
+        @pool = pool
+      end
+
+      def method_missing(name, *args, &block)
+        @pool.with { |x| x.send(name, *args, &block) }
+      end
+
+      def respond_to_missing?(name, include_all = false)
+        @pool.with { |x| x.respond_to?(name, include_all) }
+      end
+
+      def self.should_proxy?(conn)
+        defined?(::ConnectionPool) && conn.is_a?(::ConnectionPool)
+      end
+
+      def self.proxy_if_needed(conn)
+        if should_proxy?(conn)
+          ConnectionPoolProxy.new(conn)
+        else
+          conn
+        end
+      end
+    end
+  end
+end

--- a/redis-objects.gemspec
+++ b/redis-objects.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bacon"
+  spec.add_development_dependency "connection_pool"
 
   # compatability testing
   spec.add_development_dependency "redis-namespace"

--- a/spec/redis_objects_conn_spec.rb
+++ b/spec/redis_objects_conn_spec.rb
@@ -4,13 +4,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 require 'redis/objects'
+require 'connection_pool'
 
 BAD_REDIS = "totally bad bogus redis handle"
 
 # Grab a global handle
 describe 'Connection tests' do
-  it "should support overriding object handles" do
-
+  it "should support overriding object handles with a vanilla redis connection" do
     class CustomConnectionObject
       include Redis::Objects
 
@@ -41,10 +41,86 @@ describe 'Connection tests' do
     obj.default_redis_value.clear
   end
 
-  it "should support local handles" do
+  it "should support overriding object handles with a connection_pool" do
+    class CustomConnectionObject
+      include Redis::Objects
+
+      def id
+        return 1
+      end
+
+      redis_handle = ConnectionPool.new { Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 31) }
+      value :redis_value, :redis => redis_handle, :key => 'rval'
+      value :default_redis_value, :key => 'rval'
+    end
+
+    obj = CustomConnectionObject.new
+
+    obj.default_redis_value.value.should == nil
+    obj.redis_value.value.should == nil
+
+    obj.default_redis_value.value = 'foo'
+    obj.default_redis_value.value.should == 'foo'
+    obj.redis_value.value.should == nil
+
+    obj.default_redis_value.clear
+    obj.redis_value.value = 'foo'
+    obj.redis_value.value.should == 'foo'
+    obj.default_redis_value.value.should == nil
+
+    obj.redis_value.clear
+    obj.default_redis_value.clear
+  end
+
+  it "should support local handles with a vanilla redis connection" do
     Redis.current = nil  # reset from other tests
     Redis::Objects.redis = nil
     @redis_handle = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT)
+
+    # Redis.current is lazily auto-populated to touch 6379
+    # This why we choose the weird 9212 port to avoid
+    Redis.current.inspect.should == Redis.new.inspect
+    Redis::Objects.redis.inspect.should == Redis.new.inspect
+
+    v = Redis::Value.new('conn/value', @redis_handle)
+    v.clear
+    v.value = 'yay'
+    v.value.should == 'yay'
+
+    h = Redis::HashKey.new('conn/hash', @redis_handle)
+    h.clear
+    h['k'] = 'v'
+
+    l = Redis::List.new('conn/list', @redis_handle)
+    l.clear
+    l << 3
+    l << 4
+    l << 5
+
+    s = Redis::Set.new('conn/set', @redis_handle)
+    s.clear
+    s << 5
+    s << 5
+    s << 6
+    s << 7
+
+    z = Redis::SortedSet.new('conn/zset', @redis_handle)
+    z.clear
+    z['a'] = 8
+    z['b'] = 7
+    z['c'] = 9
+    z['d'] = 6
+
+    c = Redis::Counter.new('conn/counter', @redis_handle)
+    c.reset
+    c.incr(3)
+    c.decr(1)
+  end
+
+  it "should support local handles with a connection_pool" do
+    Redis.current = nil  # reset from other tests
+    Redis::Objects.redis = nil
+    @redis_handle = ConnectionPool.new { Redis.new(:host => REDIS_HOST, :port => REDIS_PORT) }
 
     # Redis.current is lazily auto-populated to touch 6379
     # This why we choose the weird 9212 port to avoid
@@ -97,7 +173,41 @@ describe 'Connection tests' do
     Redis::Counter.new('conn/counter').should == 2
   end
 
-  it "should support Redis::Objects.redis=" do
+  it "should support Redis::Objects.redis= with a connection_pool" do
+    @redis_handle = ConnectionPool.new { Redis.new(:host => REDIS_HOST, :port => REDIS_PORT) }
+
+    # Redis.current is lazily auto-populated to touch 6379
+    # This why we choose the weird 9212 port to avoid
+    Redis.current = BAD_REDIS
+    Redis::Objects.redis.should == BAD_REDIS
+
+    # This set of tests sucks, it fucks up the per-data-type handles
+    # because Redis.current is then set to a BS value, and the lazy
+    # init code in redis-rb will keep that value until we clear it.
+    # This ends up fucking any sequential tests.
+    raises_exception{ Redis::Value.new('conn/value').should.be.nil       }
+    raises_exception{ Redis::HashKey.new('conn/hash').keys.should == []  }
+    raises_exception{ Redis::List.new('conn/list').sort.should == []     }
+    raises_exception{ Redis::Set.new('conn/set').sort.should == []       }
+    raises_exception{ Redis::SortedSet.new('conn/zset').should == []     }
+    raises_exception{ Redis::Counter.new('conn/counter').get.should == 0 }
+
+    Redis::Objects.redis = @redis_handle
+    Redis::Value.new('fart').redis.is_a?(Redis::Objects::ConnectionPoolProxy).should == true
+
+    # These should now get the correct handle
+    Redis::Value.new('conn/value').should == 'yay'
+    Redis::HashKey.new('conn/hash').keys.should == ['k']
+    Redis::List.new('conn/list').sort.should  == ['3', '4', '5']
+    Redis::Set.new('conn/set').sort.should    == ['5', '6', '7']
+    Redis::SortedSet.new('conn/zset').should  == ['d', 'b', 'a', 'c']
+    Redis::Counter.new('conn/counter').should == 2
+
+  end
+
+  it "should support Redis::Objects.redis= with a vanilla redis connection" do
+    # reset redis
+    Redis::Objects.redis = nil
     @redis_handle = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT)
 
     # Redis.current is lazily auto-populated to touch 6379
@@ -130,5 +240,4 @@ describe 'Connection tests' do
     # Fix for future tests
     Redis.current = @redis_handle
   end
-
 end


### PR DESCRIPTION
The specs are a little ugly because I am not that used to **bacon**. Wasn't able to use `shared` or `context` as I would have done in **RSpec**. IMO I think the next step for this gem would be to refactor how redis connections or connection pools are provided. Once that has landed, I would factor out the redis calls into a simple facade that can delegate to a single connection or a `connection_pool`.