### PR TITLE
Simplify lock method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Redis::Objects - Map Redis types directly to Ruby objects
 =========================================================
 
 [![Build Status](https://travis-ci.org/nateware/redis-objects.png)](https://travis-ci.org/nateware/redis-objects)
-[![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MJF7JU5M7F8VL)
+[![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MJF7JU5M7F8VL) [![Code Climate](https://codeclimate.com/github/nateware/redis-objects/badges/gpa.svg)](https://codeclimate.com/github/nateware/redis-objects)
 
 This is **not** an ORM. People that are wrapping ORM’s around Redis are missing the point.
 

--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -31,38 +31,23 @@ class Redis
     # that was specified when the lock was defined.
     def lock(&block)
       start = Time.now
-      gotit = false
-      expiration = nil
       while Time.now - start < @options[:timeout]
-        expiration = generate_expiration
+        @expiration = generate_expiration
         # Use the expiration as the value of the lock.
-        gotit = redis.setnx(key, expiration)
-        break if gotit
+        @gotit = redis.setnx(key, @expiration)
+        break if @gotit
 
         # Lock is being held.  Now check to see if it's expired (if we're using
         # lock expiration).
         # See "Handling Deadlocks" section on http://redis.io/commands/setnx
-        if !@options[:expiration].nil?
-          old_expiration = redis.get(key).to_f
-
-          if old_expiration < Time.now.to_f
-            # If it's expired, use GETSET to update it.
-            expiration = generate_expiration
-            old_expiration = redis.getset(key, expiration).to_f
-
-            # Since GETSET returns the old value of the lock, if the old expiration
-            # is still in the past, we know no one else has expired the locked
-            # and we now have it.
-            if old_expiration < Time.now.to_f
-              gotit = true
-              break
-            end
-          end
+        if using_lock_expiration?
+          @gotit = lock_expired?
+          break if @gotit
         end
 
         sleep 0.1
       end
-      raise LockTimeout, "Timeout on lock #{key} exceeded #{@options[:timeout]} sec" unless gotit
+      raise LockTimeout, "Timeout on lock #{key} exceeded #{@options[:timeout]} sec" unless @gotit
       begin
         yield
       ensure
@@ -71,14 +56,36 @@ class Redis
         # it's not safe for us to remove it.  Check how much time has passed since we
         # wrote the lock key and only delete it if it hasn't expired (or we're not using
         # lock expiration)
-        if @options[:expiration].nil? || expiration > Time.now.to_f
+        if !using_lock_expiration? || @expiration > Time.now.to_f
           redis.del(key)
         end
       end
     end
 
     def generate_expiration
-      @options[:expiration].nil? ? 1 : (Time.now + @options[:expiration].to_f + 1).to_f
+      !using_lock_expiration? ? 1 : (Time.now + @options[:expiration].to_f + 1).to_f
     end
+
+    private
+
+    def using_lock_expiration?
+      !@options[:expiration].nil?
+    end
+
+    def lock_expired?
+      old_expiration = redis.get(key).to_f
+
+      if old_expiration < Time.now.to_f
+        # If it's expired, use GETSET to update it.
+        @expiration = generate_expiration
+        old_expiration = redis.getset(key, @expiration).to_f
+
+        # Since GETSET returns the old value of the lock, if the old expiration
+        # is still in the past, we know no one else has expired the locked
+        # and we now have it.
+        old_expiration < Time.now.to_f
+      end
+    end
+
   end
 end


### PR DESCRIPTION
I was looking around on Code Climate for OSS repos to contribute to and I came across redis-objects - cool lib! I tried to make something similar back in the day and couldn't get it together. I thought the lock method here could use some clarification after Code Climate pointed out it was complex. Specs pass locally and I think this is a little clearer - I also added the Code Climate badge to the README. Cheers!