### PR TITLE
Add support for expiration on HashKey#update

### DIFF
--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -169,7 +169,8 @@ class Redis
       incrbyfloat(field, -by)
     end
 
-    expiration_filter :[]=, :store, :bulk_set, :fill,
+    expiration_filter :[]=, :store,
+                      :bulk_set, :update, :fill,
                       :incrby, :incr, :incrbyfloat,
                       :decrby, :decr, :decrbyfloat
   end

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -805,6 +805,7 @@ describe Redis::HashKey do
       :store       => ['somekey', 'somevalue'],
       :[]=         => ['somekey', 'somevalue'],
       :bulk_set    => [{ 'somekey' => 'somevalue' }],
+      :update      => [{ 'somekey' => 'somevalue' }],
       :fill        => [{ 'somekey' => 'somevalue' }]
     }.each do |meth, args|
       it "#{meth} expiration: option" do

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -807,25 +807,22 @@ describe Redis::HashKey do
       :bulk_set    => [{ 'somekey' => 'somevalue' }],
       :fill        => [{ 'somekey' => 'somevalue' }]
     }.each do |meth, args|
-      describe meth do
-        it "expiration: option" do
-          @hash = Redis::HashKey.new('spec/hash_exp', :expiration => 10)
-          @hash.send(meth, *args)
-          @hash.ttl.should > 0
-          @hash.ttl.should <= 10
-        end
-        it "expireat: option" do
-          @hash = Redis::HashKey.new('spec/hash_exp', :expireat => Time.now + 10.seconds)
-          @hash.send(meth, *args)
-          @hash.ttl.should > 0
-          @hash.ttl.should <= 10
-        end
-        after do
-          @hash.clear
-        end
+      it "#{meth} expiration: option" do
+        @hash = Redis::HashKey.new('spec/hash_expiration', :expiration => 10)
+        @hash.clear
+        @hash.send(meth, *args)
+        @hash.ttl.should > 0
+        @hash.ttl.should <= 10
       end
-    end 
-  end 
+      it "#{meth} expireat: option" do
+        @hash = Redis::HashKey.new('spec/hash_expireat', :expireat => Time.now + 10.seconds)
+        @hash.clear
+        @hash.send(meth, *args)
+        @hash.ttl.should > 0
+        @hash.ttl.should <= 10
+      end
+    end
+  end
 
   after do
     @hash.clear
@@ -1285,7 +1282,7 @@ describe Redis::SortedSet do
         end
       end
     end
-  end 
+  end
 
   after do
     @set.clear

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -794,19 +794,29 @@ describe Redis::HashKey do
     block.should == "oops: missing_key"
   end
 
-  #[:[]=, :store, :bulk_set, :fill,
   describe 'with expiration' do
-    [:incrby, :incr, :incrbyfloat, :decrby, :decr, :decrbyfloat].each do |meth|
+    {
+      :incrby      => 'somekey',
+      :incr        => 'somekey',
+      :incrbyfloat => 'somekey',
+      :decrby      => 'somekey',
+      :decr        => 'somekey',
+      :decrbyfloat => 'somekey',
+      :store       => ['somekey', 'somevalue'],
+      :[]=         => ['somekey', 'somevalue'],
+      :bulk_set    => [{ 'somekey' => 'somevalue' }],
+      :fill        => [{ 'somekey' => 'somevalue' }]
+    }.each do |meth, args|
       describe meth do
         it "expiration: option" do
           @hash = Redis::HashKey.new('spec/hash_exp', :expiration => 10)
-          @hash.send(meth, 'somekey')
+          @hash.send(meth, *args)
           @hash.ttl.should > 0
           @hash.ttl.should <= 10
         end
         it "expireat: option" do
           @hash = Redis::HashKey.new('spec/hash_exp', :expireat => Time.now + 10.seconds)
-          @hash.send(meth, 'somekey')
+          @hash.send(meth, *args)
           @hash.ttl.should > 0
           @hash.ttl.should <= 10
         end


### PR DESCRIPTION
Given the following class with a `hash_key` using options for `:expiration` (or `:expireat`), the `Redis::HashKey#update` method does not set the TTL on the redis key as does its alias method, `#bulk_set`.

```ruby
class Foo
  hash_key :bar, :expiration => 1.hour

  def initialize(id); @id = id; end
  def id; @id; end
end

foo = Foo.new(1)
foo.bar.ttl
# => -2

foo.bar.update("some" => "value")
foo.bar.ttl
# => -1

foo.bar.bulk_set("another" => "value")
foo.bar.ttl
# => 3600
```

This pull request adds support for expiry options when using `#update` and provides additional tests for all the `hash_key` methods supporting expiry.