### PR TITLE
Proposal: alternative to Redis::BaseObject.expiration_filter

### DIFF
--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -25,20 +25,5 @@ class Redis
     def allow_expiration(&block)
       block.call.tap { set_expiration }
     end
-
-    class << self
-      def expiration_filter(*names)
-        names.each do |name|
-          # http://blog.jayfields.com/2006/12/ruby-alias-method-alternative.html
-          bind_method = instance_method(name)
-
-          define_method(name) do |*args, &block|
-            result = bind_method.bind(self).call(*args, &block)
-            set_expiration
-            result
-          end
-        end
-      end
-    end
   end
 end

--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -22,6 +22,10 @@ class Redis
       end
     end
 
+    def allow_expiration(&block)
+      block.call.tap { set_expiration }
+    end
+
     class << self
       def expiration_filter(*names)
         names.each do |name|

--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -106,17 +106,21 @@ class Redis
     # Set keys in bulk, takes a hash of field/values {'field1' => 'val1'}. Redis: HMSET
     def bulk_set(*args)
       raise ArgumentError, "Argument to bulk_set must be hash of key/value pairs" unless args.last.is_a?(::Hash)
-      redis.hmset(key, *args.last.inject([]){ |arr,kv|
-        arr + [kv[0], marshal(kv[1], options[:marshal_keys][kv[0]])]
-      })
+      allow_expiration do
+        redis.hmset(key, *args.last.inject([]){ |arr,kv|
+          arr + [kv[0], marshal(kv[1], options[:marshal_keys][kv[0]])]
+        })
+      end
     end
     alias_method :update, :bulk_set
 
     # Set keys in bulk if they do not exist. Takes a hash of field/values {'field1' => 'val1'}. Redis: HSETNX
     def fill(pairs={})
       raise ArgumentError, "Arugment to fill must be a hash of key/value pairs" unless pairs.is_a?(::Hash)
-      pairs.each do |field, value|
-        redis.hsetnx(key, field, marshal(value, options[:marshal_keys][field]))
+      allow_expiration do
+        pairs.each do |field, value|
+          redis.hsetnx(key, field, marshal(value, options[:marshal_keys][field]))
+        end
       end
     end
 
@@ -139,11 +143,13 @@ class Redis
 
     # Increment value by integer at field. Redis: HINCRBY
     def incrby(field, by=1)
-      ret = redis.hincrby(key, field, by)
-      unless ret.is_a? Array
-        ret.to_i
-      else
-        nil
+      allow_expiration do
+        ret = redis.hincrby(key, field, by)
+        unless ret.is_a? Array
+          ret.to_i
+        else
+          nil
+        end
       end
     end
     alias_method :incr, :incrby
@@ -156,11 +162,13 @@ class Redis
 
     # Increment value by float at field. Redis: HINCRBYFLOAT
     def incrbyfloat(field, by=1.0)
-      ret = redis.hincrbyfloat(key, field, by)
-      unless ret.is_a? Array
-        ret.to_f
-      else
-        nil
+      allow_expiration do
+        ret = redis.hincrbyfloat(key, field, by)
+        unless ret.is_a? Array
+          ret.to_f
+        else
+          nil
+        end
       end
     end
 
@@ -168,10 +176,5 @@ class Redis
     def decrbyfloat(field, by=1.0)
       incrbyfloat(field, -by)
     end
-
-    expiration_filter :[]=, :store, :bulk_set, :fill,
-                      :incrby, :incr, :incrbyfloat,
-                      :decrby, :decr, :decrbyfloat
   end
 end
-

--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -18,7 +18,9 @@ class Redis
 
     # Redis: HSET
     def store(field, value)
-      redis.hset(key, field, marshal(value, options[:marshal_keys][field]))
+      allow_expiration do
+        redis.hset(key, field, marshal(value, options[:marshal_keys][field]))
+      end
     end
     alias_method :[]=, :store
 

--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -21,13 +21,17 @@ class Redis
 
     # Add a member before or after pivot in the list. Redis: LINSERT
     def insert(where,pivot,value)
-      redis.linsert(key,where,marshal(pivot),marshal(value))
+      allow_expiration do
+        redis.linsert(key,where,marshal(pivot),marshal(value))
+      end
     end
 
     # Add a member to the end of the list. Redis: RPUSH
     def push(*values)
-      redis.rpush(key, values.map{|v| marshal(v) })
-      redis.ltrim(key, -options[:maxlength], -1) if options[:maxlength]
+      allow_expiration do
+        redis.rpush(key, values.map{|v| marshal(v) })
+        redis.ltrim(key, -options[:maxlength], -1) if options[:maxlength]
+      end
     end
 
     # Remove a member from the end of the list. Redis: RPOP
@@ -49,8 +53,10 @@ class Redis
 
     # Add a member to the start of the list. Redis: LPUSH
     def unshift(*values)
-      redis.lpush(key, values.map{|v| marshal(v) })
-      redis.ltrim(key, 0, options[:maxlength] - 1) if options[:maxlength]
+      allow_expiration do
+        redis.lpush(key, values.map{|v| marshal(v) })
+        redis.ltrim(key, 0, options[:maxlength] - 1) if options[:maxlength]
+      end
     end
 
     # Remove a member from the start of the list. Redis: LPOP
@@ -85,7 +91,9 @@ class Redis
 
     # Same functionality as Ruby arrays.
     def []=(index, value)
-      redis.lset(key, index, marshal(value))
+      allow_expiration do
+        redis.lset(key, index, marshal(value))
+      end
     end
 
     # Delete the element(s) from the list that match name. If count is specified,
@@ -142,7 +150,5 @@ class Redis
     def to_s
       values.join(', ')
     end
-
-    expiration_filter :[]=, :push, :<<, :insert, :unshift
   end
 end

--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -21,7 +21,9 @@ class Redis
     # Add the specified value to the set only if it does not exist already.
     # Redis: SADD
     def add(value)
-      redis.sadd(key, marshal(value)) if value.nil? || !Array(value).empty?
+      allow_expiration do
+        redis.sadd(key, marshal(value)) if value.nil? || !Array(value).empty?
+      end
     end
 
     # Remove and return a random member.  Redis: SPOP
@@ -180,14 +182,11 @@ class Redis
       members.join(', ')
     end
 
-    expiration_filter :add
-
     private
 
     def keys_from_objects(sets)
       raise ArgumentError, "Must pass in one or more set names" if sets.empty?
       sets.collect{|set| set.is_a?(Redis::Set) ? set.key : set}
     end
-
   end
 end

--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -23,7 +23,9 @@ class Redis
     # arguments to this are flipped; the member comes first rather than
     # the score, since the member is the unique item (not the score).
     def add(member, score)
-      redis.zadd(key, score, marshal(member))
+      allow_expiration do
+        redis.zadd(key, score, marshal(member))
+      end
     end
 
     # Add a list of members and their corresponding value (or a hash mapping
@@ -31,8 +33,10 @@ class Redis
     # the member comes first rather than the score, since the member is the unique
     # item (not the score).
     def merge(values)
-      vals = values.map{|v,s| [s, marshal(v)] }
-      redis.zadd(key, vals)
+      allow_expiration do
+        vals = values.map{|v,s| [s, marshal(v)] }
+        redis.zadd(key, vals)
+      end
     end
     alias_method :add_all, :merge
 
@@ -155,7 +159,9 @@ class Redis
 
     # Delete the value from the set.  Redis: ZREM
     def delete(value)
-      redis.zrem(key, marshal(value))
+      allow_expiration do
+        redis.zrem(key, marshal(value))
+      end
     end
 
     # Delete element if it matches block
@@ -173,14 +179,18 @@ class Redis
     # Increment the rank of that member atomically and return the new value. This
     # method is aliased as incr() for brevity. Redis: ZINCRBY
     def increment(member, by=1)
-      redis.zincrby(key, by, marshal(member)).to_i
+      allow_expiration do
+        zincrby(member, by)
+      end
     end
     alias_method :incr, :increment
     alias_method :incrby, :increment
 
     # Convenience to calling increment() with a negative number.
     def decrement(member, by=1)
-      redis.zincrby(key, -by, marshal(member)).to_i
+      allow_expiration do
+        zincrby(member, -by)
+      end
     end
     alias_method :decr, :decrement
     alias_method :decrby, :decrement
@@ -206,8 +216,10 @@ class Redis
     # Calculate the intersection and store it in Redis as +name+. Returns the number
     # of elements in the stored intersection. Redis: SUNIONSTORE
     def interstore(name, *sets)
-      opts = sets.last.is_a?(Hash) ? sets.pop : {}
-      redis.zinterstore(key_from_object(name), keys_from_objects([self] + sets), opts)
+      allow_expiration do
+        opts = sets.last.is_a?(Hash) ? sets.pop : {}
+        redis.zinterstore(key_from_object(name), keys_from_objects([self] + sets), opts)
+      end
     end
 
     # Return the union with another set.  Can pass it either another set
@@ -230,8 +242,10 @@ class Redis
     # Calculate the union and store it in Redis as +name+. Returns the number
     # of elements in the stored union. Redis: SUNIONSTORE
     def unionstore(name, *sets)
-      opts = sets.last.is_a?(Hash) ? sets.pop : {}
-      redis.zunionstore(key_from_object(name), keys_from_objects([self] + sets), opts)
+      allow_expiration do
+        opts = sets.last.is_a?(Hash) ? sets.pop : {}
+        redis.zunionstore(key_from_object(name), keys_from_objects([self] + sets), opts)
+      end
     end
 
     # Return the difference vs another set.  Can pass it either another set
@@ -304,10 +318,6 @@ class Redis
       !redis.zscore(key, marshal(value)).nil?
     end
 
-    expiration_filter :[]=, :add, :merge, :delete,
-                      :increment, :incr, :incrby, :decrement, :decr, :decrby,
-                      :intersection, :interstore, :unionstore, :diffstore
-
     private
     def key_from_object(set)
       set.is_a?(Redis::SortedSet) ? set.key : set
@@ -316,6 +326,10 @@ class Redis
     def keys_from_objects(sets)
       raise ArgumentError, "Must pass in one or more set names" if sets.empty?
       sets.collect{|set| set.is_a?(Redis::SortedSet) || set.is_a?(Redis::Set) ? set.key : set}
+    end
+
+    def zincrby(member, by)
+      redis.zincrby(key, by, marshal(member)).to_i
     end
   end
 end

--- a/lib/redis/value.rb
+++ b/lib/redis/value.rb
@@ -15,10 +15,12 @@ class Redis
     end
 
     def value=(val)
-      if val.nil?
-        delete
-      else
-        redis.set key, marshal(val)
+      allow_expiration do
+        if val.nil?
+          delete
+        else
+          redis.set key, marshal(val)
+        end
       end
     end
     alias_method :set, :value=
@@ -40,7 +42,5 @@ class Redis
     def method_missing(*args)
       self.value.send *args
     end
-
-    expiration_filter :value=
   end
 end

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -340,26 +340,58 @@ describe Redis::List do
   end
 
   describe 'with expiration' do
-    [:[]=, :push, :<<, :insert, :unshift].each do |meth|
-      describe meth do
-        it 'expiration: option' do
-          @list = Redis::List.new('spec/list_exp', :expiration => 10)
-          @list << 'val'
-          @list.ttl.should > 0
-          @list.ttl.should <= 10
-        end
-
-        it 'expireat: option' do
-          @list = Redis::List.new('spec/list_exp', :expireat => Time.now + 10.seconds)
-          @list << 'val'
-          @list.ttl.should > 0
-          @list.ttl.should <= 10
-        end
-      end
-
-      after do
+    [:push, :<<, :unshift].each do |meth, args|
+      it "#{meth} expiration: option" do
+        @list = Redis::List.new('spec/list_exp', :expiration => 10)
         @list.clear
+        @list.send(meth, 'val')
+        @list.ttl.should > 0
+        @list.ttl.should <= 10
       end
+
+      it "#{meth} expireat: option" do
+        @list = Redis::List.new('spec/list_exp', :expireat => Time.now + 10.seconds)
+        @list.clear
+        @list.send(meth, 'val')
+        @list.ttl.should > 0
+        @list.ttl.should <= 10
+      end
+    end
+
+    it "[]= expiration: option" do
+      @list = Redis::List.new('spec/list_exp', :expiration => 10)
+      @list.clear
+      @list.redis.rpush(@list.key, 'hello')
+      @list[0] = 'world'
+      @list.ttl.should > 0
+      @list.ttl.should <= 10
+    end
+
+    it "[]= expireat: option" do
+      @list = Redis::List.new('spec/list_exp', :expireat => Time.now + 10.seconds)
+      @list.clear
+      @list.redis.rpush(@list.key, 'hello')
+      @list[0] = 'world'
+      @list.ttl.should > 0
+      @list.ttl.should <= 10
+    end
+
+    it "insert expiration: option" do
+      @list = Redis::List.new('spec/list_exp', :expiration => 10)
+      @list.clear
+      @list.redis.rpush(@list.key, 'hello')
+      @list.insert 'BEFORE', 'hello', 'world'
+      @list.ttl.should > 0
+      @list.ttl.should <= 10
+    end
+
+    it "insert expireat: option" do
+      @list = Redis::List.new('spec/list_exp', :expireat => Time.now + 10.seconds)
+      @list.clear
+      @list.redis.rpush(@list.key, 'hello')
+      @list.insert 'BEFORE', 'hello', 'world'
+      @list.ttl.should > 0
+      @list.ttl.should <= 10
     end
   end
 

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -18,7 +18,7 @@ describe Redis::Value do
     @value = Redis::Value.new('spec/value', :default => false, :marshal => true)
     @value.value.should == false
   end
-  
+
   it "should handle simple values" do
     @value.should == nil
     @value.value = 'Trevor Hoffman'
@@ -109,17 +109,21 @@ describe Redis::Value do
     @value.nil?.should == true
   end
 
-  it 'should set time to live in seconds when expiration option assigned' do
-    @value = Redis::Value.new('spec/value', :expiration => 10)
-    @value.value = 'monkey'
-    @value.ttl.should > 0
-    @value.ttl.should <= 10
-  end
+  describe "with expiration" do
+    [:value=, :set].each do |meth|
+      it "should set time to live in seconds when expiration option assigned" do
+        @value = Redis::Value.new('spec/value', :expiration => 10)
+        @value.send(meth, 'monkey')
+        @value.ttl.should > 0
+        @value.ttl.should <= 10
+      end
 
-  it 'should set expiration when expireat option assigned' do
-    @value = Redis::Value.new('spec/value', :expireat => Time.now + 10.seconds)
-    @value.value = 'monkey'
-    @value.ttl.should > 0
+      it "should set expiration when expireat option assigned" do
+        @value = Redis::Value.new('spec/value', :expireat => Time.now + 10.seconds)
+        @value.send(meth, 'monkey')
+        @value.ttl.should > 0
+      end
+    end
   end
 
   after do

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -1025,18 +1025,22 @@ describe Redis::Set do
     @set_1.redis.del SORT_STORE[:store]
   end
 
-  it 'should set time to live in seconds when expiration option assigned' do
-    @set = Redis::Set.new('spec/set', :expiration => 10)
-    @set << 'val'
-    @set.ttl.should > 0
-    @set.ttl.should <= 10
-  end
+  describe "with expiration" do
+    [:<<, :add].each do |meth|
+      it "should set time to live in seconds when expiration option assigned" do
+        @set = Redis::Set.new('spec/set', :expiration => 10)
+        @set.send(meth, 'val')
+        @set.ttl.should > 0
+        @set.ttl.should <= 10
+      end
 
-  it 'should set expiration when expireat option assigned' do
-    @set = Redis::Set.new('spec/set', :expireat => Time.now + 10.seconds)
-    @set << 'val'
-    @set.ttl.should > 0
-    @set.ttl.should <= 10
+      it "should set expiration when expireat option assigned" do
+        @set = Redis::Set.new('spec/set', :expireat => Time.now + 10.seconds)
+        @set.send(meth, 'val')
+        @set.ttl.should > 0
+        @set.ttl.should <= 10
+      end
+    end
   end
 
   after do

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -1295,23 +1295,77 @@ describe Redis::SortedSet do
 
   describe "with expiration" do
     [:[]=, :add, :increment, :incr, :incrby, :decrement, :decr, :decrby].each do |meth|
-      describe meth do
-        it "expiration: option" do
-          @hash = Redis::SortedSet.new('spec/zset_exp', :expiration => 10)
-          @hash.send(meth, 'somekey', 12)
-          @hash.ttl.should > 0
-          @hash.ttl.should <= 10
-        end
-        it "expireat: option" do
-          @hash = Redis::SortedSet.new('spec/zset_exp', :expireat => Time.now + 10.seconds)
-          @hash.send(meth, 'somekey', 12)
-          @hash.ttl.should > 0
-          @hash.ttl.should <= 10
-        end
-        after do
-          @hash.clear
-        end
+      it "#{meth} expiration: option" do
+        @set = Redis::SortedSet.new('spec/zset_exp', :expiration => 10)
+        @set.clear
+        @set.send(meth, 'somekey', 12)
+        @set.ttl.should > 0
+        @set.ttl.should <= 10
       end
+      it "#{meth} expireat: option" do
+        @set = Redis::SortedSet.new('spec/zset_exp', :expireat => Time.now + 10.seconds)
+        @set.clear
+        @set.send(meth, 'somekey', 12)
+        @set.ttl.should > 0
+        @set.ttl.should <= 10
+      end
+    end
+
+    [:merge, :add_all].each do |meth|
+      it "#{meth} expiration: option" do
+        @set = Redis::SortedSet.new('spec/zset_exp', :expiration => 10)
+        @set.clear
+        @set.send(meth, 'somekey' => 12)
+        @set.ttl.should > 0
+        @set.ttl.should <= 10
+      end
+      it "#{meth} expireat: option" do
+        @set = Redis::SortedSet.new('spec/zset_exp', :expireat => Time.now + 10.seconds)
+        @set.clear
+        @set.send(meth, 'somekey' => 12)
+        @set.ttl.should > 0
+        @set.ttl.should <= 10
+      end
+    end
+
+    [:unionstore, :interstore].each do |meth|
+      it "#{meth} expiration: option" do
+        @set = Redis::SortedSet.new('spec/zset_exp', :expiration => 10)
+        @set.clear
+        @set.redis.zadd(@set.key, 1, "1")
+        @set.send(meth, 'sets', Redis::SortedSet.new('other'))
+        @set.ttl.should > 0
+        @set.ttl.should <= 10
+      end
+
+      it "#{meth} expireat: option" do
+        @set = Redis::SortedSet.new('spec/zset_exp', :expireat => Time.now + 10.seconds)
+        @set.clear
+        @set.redis.zadd(@set.key, 1, "1")
+        @set.send(meth, 'sets', Redis::SortedSet.new('other'))
+        @set.ttl.should > 0
+        @set.ttl.should <= 10
+      end
+    end
+
+    it "delete expiration: option" do
+      @set = Redis::SortedSet.new('spec/zset_exp', :expiration => 10)
+      @set.clear
+      @set.redis.zadd(@set.key, 1, "1")
+      @set.redis.zadd(@set.key, 2, "2")
+      @set.delete("2")
+      @set.ttl.should > 0
+      @set.ttl.should <= 10
+    end
+
+    it "delete expireat: option" do
+      @set = Redis::SortedSet.new('spec/zset_exp', :expireat => Time.now + 10.seconds)
+      @set.clear
+      @set.redis.zadd(@set.key, 1, "1")
+      @set.redis.zadd(@set.key, 2, "2")
+      @set.delete("2")
+      @set.ttl.should > 0
+      @set.ttl.should <= 10
     end
   end
 

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -127,7 +127,6 @@ describe Redis::Value do
   end
 end
 
-
 describe Redis::List do
   describe "as a bounded list" do
     before do
@@ -472,7 +471,7 @@ describe Redis::Counter do
       @counter.ttl.should <= 10
     end
 
-   [:increment, :incr, :incrby, :incrbyfloat, 
+   [:increment, :incr, :incrby, :incrbyfloat,
     :decrement, :decr, :decrby, :decrbyfloat, :reset].each do |meth|
       describe meth do
         it "expiration: option" do
@@ -605,7 +604,6 @@ describe Redis::Lock do
     REDIS_HANDLE.get("test_lock").should.not.be.nil
   end
 end
-
 
 describe Redis::HashKey do
   describe "With Marshal" do
@@ -846,8 +844,8 @@ describe Redis::HashKey do
           @hash.clear
         end
       end
-    end 
-  end 
+    end
+  end
 
   after do
     @hash.clear
@@ -1307,7 +1305,7 @@ describe Redis::SortedSet do
         end
       end
     end
-  end 
+  end
 
   after do
     @set.clear


### PR DESCRIPTION
PRs #172 and #173 highlight a weakness in the current implementation supporting expiration options on class macros, notably in `Redis::BaseObject.expiration_filter`:

https://github.com/nateware/redis-objects/blob/dffb9a0e9ab6159cd3ccf1dffdafb0265c8f2d88/lib/redis/base_object.rb#L26

This approach requires maintainers to register all appropriate methods and theirs aliases with  `expiration_filter`. This is problematic for `Redis::Objects` which makes heavy use of alias methods in subclasses.

An alternative approach ideally obviates the need for a separate registry, makes it explicit that expiration is supported within the method definition itself, and handles alias methods seamlessly.

I propose replacing the current implementation with the following:

```ruby
# Redis::BaseObject
def allow_expiration(&block)
  block.call.tap { set_expiration }
end
```

Subclasses would simply pass the method implementation as a block to `allow_expiration`:

```ruby
# Redis::HashKey
def store(field, value)
  allow_expiration do
    redis.hset(key, field, marshal(value, options[:marshal_keys][field]))
  end
end
alias_method :[]=, :store
```

This PR depends on tests implemented in #172 and #173.