### PR TITLE
overwriting ttl on each write

### DIFF
--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -30,7 +30,7 @@ class Redis
 
     private
     def overwrite_ttl?
-      !@options[:overwrite_ttl].nil?
+      @options[:overwrite_ttl]
     end
   end
 end

--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -15,15 +15,22 @@ class Redis
     alias :inspect :to_s  # Ruby 1.9.2
 
     def set_expiration
-      if !@options[:expiration].nil?
-        redis.expire(@key, @options[:expiration]) if redis.ttl(@key) < 0
-      elsif !@options[:expireat].nil?
-        redis.expireat(@key, @options[:expireat].to_i) if redis.ttl(@key) < 0
+      if overwrite_ttl? || redis.ttl(@key) < 0
+        if !@options[:expiration].nil?
+          redis.expire(@key, @options[:expiration])
+        elsif !@options[:expireat].nil?
+          redis.expireat(@key, @options[:expireat].to_i)
+        end
       end
     end
 
     def allow_expiration(&block)
       block.call.tap { set_expiration }
+    end
+
+    private
+    def overwrite_ttl?
+      @options[:overwrite_ttl].present?
     end
   end
 end

--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -30,7 +30,7 @@ class Redis
 
     private
     def overwrite_ttl?
-      @options[:overwrite_ttl].present?
+      !@options[:overwrite_ttl].nil?
     end
   end
 end


### PR DESCRIPTION
So... This is just a suggestion. What do you think? Should we make it off by default to preserve backwards compatibility? Or maybe turn it on by default and make a warning in readme? Or make something like `Redis::Objects.overwrite_ttl = true` (though this one is a little bit ugly)?
