### PR TITLE
add redis key options prefix_model

### DIFF
--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -187,7 +187,7 @@ class Redis
 
       def redis_field_key(name, options={}) #:nodoc:
         id = send(self.class.redis_id_field)
-        model_id = send(options[:prefix_model].to_s.capitalize.constantize.reflections[options[:prefix_model]])
+        model_id = send(self.class.reflections[options[:prefix_model]].foreign_key)
         self.class.redis_field_key(name, id, self, options.merge(model_id: model_id))
       end
     end

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -105,12 +105,16 @@ class Redis
 
       # Set the Redis redis_prefix to use. Defaults to model_name
       def redis_prefix=(redis_prefix) @redis_prefix = redis_prefix end
-      def redis_prefix(klass = self) #:nodoc:
-        @redis_prefix ||= klass.name.to_s.
-          sub(%r{(.*::)}, '').
-          gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-          gsub(/([a-z\d])([A-Z])/,'\1_\2').
-          downcase
+      def redis_prefix(klass = self, options = {}) #:nodoc:
+        @redis_prefix ||= "#{prefix_model(options)}#{klass.name.to_s.
+                          sub(%r{(.*::)}, '').
+                          gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+                          gsub(/([a-z\d])([A-Z])/,'\1_\2').
+                          downcase}"
+      end
+
+      def prefix_model(options)
+        "#{options[:prefix_model]}:#{self.send(self.class.reflections[options[:prefix_model]])}:" if options[:prefix_model].present?
       end
 
       def redis_options(name)
@@ -128,7 +132,7 @@ class Redis
         end
       end
 
-      def redis_field_key(name, id=nil, context=self) #:nodoc:
+      def redis_field_key(name, id=nil, context=self, options) #:nodoc:
         klass = first_ancestor_with(name)
         # READ THIS: This can never ever ever ever change or upgrades will corrupt all data
         # I don't think people were using Proc as keys before (that would create a weird key). Should be ok
@@ -144,7 +148,7 @@ class Redis
               "[#{klass.redis_objects[name.to_sym]}] Attempt to address redis-object " +
               ":#{name} on class #{klass.name} with nil id (unsaved record?) [object_id=#{object_id}]"
           end
-          "#{redis_prefix(klass)}:#{id}:#{name}"
+          "#{redis_prefix(klass, options)}:#{id}:#{name}"
         end
       end
 
@@ -181,9 +185,9 @@ class Redis
         return self.class.redis_field_redis(name)
       end
 
-      def redis_field_key(name) #:nodoc:
+      def redis_field_key(name, options={}) #:nodoc:
         id = send(self.class.redis_id_field)
-        self.class.redis_field_key(name, id, self)
+        self.class.redis_field_key(name, id, self, options)
       end
     end
   end

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -114,7 +114,7 @@ class Redis
       end
 
       def prefix_model(options)
-        "#{options[:prefix_model]}:#{options[:model_id]}:" if options[:prefix_model].present?
+        "#{options[:prefix_model]}:#{options[:model_id]}:" if options[:prefix_model].present? && options[:model_id].present?
       end
 
       def redis_options(name)

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -114,7 +114,7 @@ class Redis
       end
 
       def prefix_model(options)
-        "#{options[:prefix_model]}:#{self.send(self.class.reflections[options[:prefix_model]])}:" if options[:prefix_model].present?
+        "#{options[:prefix_model]}:#{self.send(options[:prefix_model].to_s.capitalize.constantize.reflections[options[:prefix_model]])}:" if options[:prefix_model].present?
       end
 
       def redis_options(name)

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -114,7 +114,7 @@ class Redis
       end
 
       def prefix_model(options)
-        "#{options[:prefix_model]}:#{self.send(options[:prefix_model].to_s.capitalize.constantize.reflections[options[:prefix_model]])}:" if options[:prefix_model].present?
+        "#{options[:prefix_model]}:#{options[:model_id]}}:" if options[:prefix_model].present?
       end
 
       def redis_options(name)
@@ -187,7 +187,8 @@ class Redis
 
       def redis_field_key(name, options={}) #:nodoc:
         id = send(self.class.redis_id_field)
-        self.class.redis_field_key(name, id, self, options)
+        model_id = send(options[:prefix_model].to_s.capitalize.constantize.reflections[options[:prefix_model]])
+        self.class.redis_field_key(name, id, self, options.merge(model_id: model_id))
       end
     end
   end

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -187,8 +187,8 @@ class Redis
 
       def redis_field_key(name, options={}) #:nodoc:
         id = send(self.class.redis_id_field)
-        model_id = send(self.class.reflections[options[:prefix_model]].foreign_key)
-        self.class.redis_field_key(name, id, self, options.merge(model_id: model_id))
+        options.merge!(model_id: send(self.class.reflections[options[:prefix_model]].foreign_key) if options[:prefix_model].present?
+        self.class.redis_field_key(name, id, self, options)
       end
     end
   end

--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -114,7 +114,7 @@ class Redis
       end
 
       def prefix_model(options)
-        "#{options[:prefix_model]}:#{options[:model_id]}}:" if options[:prefix_model].present?
+        "#{options[:prefix_model]}:#{options[:model_id]}:" if options[:prefix_model].present?
       end
 
       def redis_options(name)

--- a/lib/redis/objects/counters.rb
+++ b/lib/redis/objects/counters.rb
@@ -29,7 +29,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::Counter.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/hashes.rb
+++ b/lib/redis/objects/hashes.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::HashKey.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/lists.rb
+++ b/lib/redis/objects/lists.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::List.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/locks.rb
+++ b/lib/redis/objects/locks.rb
@@ -24,7 +24,7 @@ class Redis
               instance_variable_get("@#{lock_name}") or
                 instance_variable_set("@#{lock_name}",
                   Redis::Lock.new(
-                    redis_field_key(lock_name), redis_field_redis(lock_name), redis_objects[lock_name.to_sym]
+                    redis_field_key(lock_name, options), redis_field_redis(lock_name), redis_objects[lock_name.to_sym]
                   )
                 )
             end

--- a/lib/redis/objects/sets.rb
+++ b/lib/redis/objects/sets.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::Set.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/sorted_sets.rb
+++ b/lib/redis/objects/sorted_sets.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::SortedSet.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/values.rb
+++ b/lib/redis/objects/values.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::Value.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end


### PR DESCRIPTION
I want to add the prefix，but redis_prefix method not suitable. I nee dynamic setting the value of the property.
example:
staff.rb
belongs_to :group
hash_key :user_info, prefix_model: :group

redis key: "group:1:staff:1:user_info"