### PR TITLE
add prefix_model options

### DIFF
--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -105,12 +105,16 @@ class Redis
 
       # Set the Redis redis_prefix to use. Defaults to model_name
       def redis_prefix=(redis_prefix) @redis_prefix = redis_prefix end
-      def redis_prefix(klass = self) #:nodoc:
-        @redis_prefix ||= klass.name.to_s.
-          sub(%r{(.*::)}, '').
-          gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-          gsub(/([a-z\d])([A-Z])/,'\1_\2').
-          downcase
+      def redis_prefix(klass = self, options = {}) #:nodoc:
+        @redis_prefix ||= "#{prefix_model(options)}#{klass.name.to_s.
+                          sub(%r{(.*::)}, '').
+                          gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+                          gsub(/([a-z\d])([A-Z])/,'\1_\2').
+                          downcase}"
+      end
+
+      def prefix_model(options)
+        "#{options[:prefix_model]}:#{options[:model_id]}:" if options[:prefix_model].present? && options[:model_id].present?
       end
 
       def redis_options(name)
@@ -128,7 +132,7 @@ class Redis
         end
       end
 
-      def redis_field_key(name, id=nil, context=self) #:nodoc:
+      def redis_field_key(name, id=nil, context=self, options) #:nodoc:
         klass = first_ancestor_with(name)
         # READ THIS: This can never ever ever ever change or upgrades will corrupt all data
         # I don't think people were using Proc as keys before (that would create a weird key). Should be ok
@@ -144,7 +148,7 @@ class Redis
               "[#{klass.redis_objects[name.to_sym]}] Attempt to address redis-object " +
               ":#{name} on class #{klass.name} with nil id (unsaved record?) [object_id=#{object_id}]"
           end
-          "#{redis_prefix(klass)}:#{id}:#{name}"
+          "#{redis_prefix(klass, options)}:#{id}:#{name}"
         end
       end
 
@@ -181,9 +185,10 @@ class Redis
         return self.class.redis_field_redis(name)
       end
 
-      def redis_field_key(name) #:nodoc:
+      def redis_field_key(name, options={}) #:nodoc:
         id = send(self.class.redis_id_field)
-        self.class.redis_field_key(name, id, self)
+        options.merge!(model_id: send(self.class.reflections[options[:prefix_model]].foreign_key)) if options[:prefix_model].present?
+        self.class.redis_field_key(name, id, self, options)
       end
     end
   end

--- a/lib/redis/objects/counters.rb
+++ b/lib/redis/objects/counters.rb
@@ -29,7 +29,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::Counter.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/hashes.rb
+++ b/lib/redis/objects/hashes.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::HashKey.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/lists.rb
+++ b/lib/redis/objects/lists.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::List.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/locks.rb
+++ b/lib/redis/objects/locks.rb
@@ -24,7 +24,7 @@ class Redis
               instance_variable_get("@#{lock_name}") or
                 instance_variable_set("@#{lock_name}",
                   Redis::Lock.new(
-                    redis_field_key(lock_name), redis_field_redis(lock_name), redis_objects[lock_name.to_sym]
+                    redis_field_key(lock_name, options), redis_field_redis(lock_name), redis_objects[lock_name.to_sym]
                   )
                 )
             end

--- a/lib/redis/objects/sets.rb
+++ b/lib/redis/objects/sets.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::Set.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/sorted_sets.rb
+++ b/lib/redis/objects/sorted_sets.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::SortedSet.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end

--- a/lib/redis/objects/values.rb
+++ b/lib/redis/objects/values.rb
@@ -21,7 +21,7 @@ class Redis
               instance_variable_get("@#{name}") or
                 instance_variable_set("@#{name}",
                   Redis::Value.new(
-                    redis_field_key(name), redis_field_redis(name), redis_options(name)
+                    redis_field_key(name, options), redis_field_redis(name), redis_options(name)
                   )
                 )
             end


### PR DESCRIPTION
By default, the redis key is "`model:id:key`". I want to dynamically add the value of the property. But the redis_prefix method is not appropriate. add options prefix_model: :group
example:

``` ruby
class Staff < ActiveRecord::Base
   include Redis::Objects
   belongs_to :group

   hash_key :extra, prefix_model: :group
end
```

the redis key is "group:1:staff:1:extra"
