### PR TITLE
Bug fix pipelined calls

### DIFF
--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -23,7 +23,9 @@ class Redis
     end
 
     def allow_expiration(&block)
-      block.call.tap { set_expiration }
+      result = block.call
+      set_expiration
+      result
     end
   end
 end

--- a/spec/redis_objects_conn_spec.rb
+++ b/spec/redis_objects_conn_spec.rb
@@ -240,4 +240,15 @@ describe 'Connection tests' do
     # Fix for future tests
     Redis.current = @redis_handle
   end
+
+  it "should support pipelined changes" do
+    list = Redis::List.new('pipelined/list')
+    key = Redis::HashKey.new('pipelined/hash')
+    Redis::Objects.redis.pipelined do
+      key['foo'] = 'bar'
+      list.push 1, 2
+    end
+    key.all.should == { 'foo' => 'bar' }
+    list.values.should == %w[1 2]
+  end
 end


### PR DESCRIPTION
Fixes #185 

Use of #tap appears problematic when dealing with `Redis::Future`. This PR reproduces the issue and replaces use of #tap in `BaseObject#allow_expiration` with a local variable.