### PR TITLE
Bug fix for #to_json

### DIFF
--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -28,8 +28,18 @@ class Redis
       result
     end
 
-    def to_json(options = {})
-      { "key" => @key, "options" => @options, "value" => value }.to_json(options)
+    def to_json(*args)
+      to_hash.to_json(*args)
+    rescue NoMethodError => e
+      raise e.class, "The current runtime does not provide a `to_json` implementation. Require 'json' or another JSON library and try again."
+    end
+
+    def as_json(*)
+      to_hash
+    end
+
+    def to_hash
+      { "key" => @key, "options" => @options, "value" => value }
     end
   end
 end

--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -27,5 +27,9 @@ class Redis
       set_expiration
       result
     end
+
+    def to_json(options = {})
+      { "key" => @key, "options" => @options, "value" => value }.to_json(options)
+    end
   end
 end

--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -72,6 +72,7 @@ class Redis
       h
     end
     alias_method :clone, :all
+    alias_method :value, :all
 
     # Enumerate through all fields. Redis: HGETALL
     def each(&block)

--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -179,5 +179,9 @@ class Redis
     def decrbyfloat(field, by=1.0)
       incrbyfloat(field, -by)
     end
+
+    def as_json(*)
+      to_hash
+    end
   end
 end

--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -151,5 +151,9 @@ class Redis
     def to_s
       values.join(', ')
     end
+
+    def as_json(*)
+      to_hash
+    end
   end
 end

--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -70,6 +70,7 @@ class Redis
       vals.nil? ? [] : vals
     end
     alias_method :get, :values
+    alias_method :value, :values
 
     # Same functionality as Ruby arrays.  If a single number is given, return
     # just the element at that index using Redis: LINDEX. Otherwise, return

--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -26,6 +26,10 @@ class Redis
     end
     alias_method :delete, :clear
 
+    def value
+      nil
+    end
+
     # Get the lock and execute the code block. Any other code that needs the lock
     # (on any server) will spin waiting for the lock up to the :timeout
     # that was specified when the lock was defined.

--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -185,6 +185,10 @@ class Redis
       members.join(', ')
     end
 
+    def as_json(*)
+      to_hash
+    end
+
     private
 
     def keys_from_objects(sets)

--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -50,6 +50,7 @@ class Redis
       vals.nil? ? [] : vals.map{|v| unmarshal(v) }
     end
     alias_method :get, :members
+    alias_method :value, :members
 
     # Returns true if the specified value is in the set.  Redis: SISMEMBER
     def member?(value)

--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -92,6 +92,7 @@ class Redis
     def members(options={})
       range(0, -1, options) || []
     end
+    alias_method :value, :members
 
     # Return a range of values from +start_index+ to +end_index+.  Can also use
     # the familiar list[start,end] Ruby syntax. Redis: ZRANGE

--- a/lib/redis/value.rb
+++ b/lib/redis/value.rb
@@ -36,8 +36,6 @@ class Redis
 
     def ==(other); value == other end
     def nil?; value.nil? end
-    def as_json(*args); value.as_json *args end
-    def to_json(*args); value.to_json *args end
 
     def method_missing(*args)
       self.value.send *args

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -348,6 +348,11 @@ describe Redis::List do
       JSON.parse(@list.to_json)['value'].should == ['a']
     end
 
+    it "should support as_json" do
+      @list << 'a'
+      @list.as_json['value'].should == ['a']
+    end
+
     after do
       @list.clear
     end
@@ -480,6 +485,11 @@ describe Redis::Counter do
   it "should support #to_json" do
     @counter.increment
     JSON.parse(@counter.to_json)['value'].should == 1
+  end
+
+  it "should support #as_json" do
+    @counter.increment
+    @counter.as_json['value'].should == 1
   end
 
   describe 'with expiration' do
@@ -625,6 +635,10 @@ describe Redis::Lock do
 
   it "should respond to #to_json" do
     Redis::Lock.new(:test_lock).to_json.should.be.kind_of(String)
+  end
+
+  it "should respond to #as_json" do
+    Redis::Lock.new(:test_lock).as_json.should.be.kind_of(Hash)
   end
 end
 
@@ -858,6 +872,11 @@ describe Redis::HashKey do
     JSON.parse(@hash.to_json)['value'].should == { "abc" => "123" }
   end
 
+  it "should respond to #as_json" do
+    @hash['abc'] = "123"
+    @hash.as_json['value'].should == { "abc" => "123" }
+  end
+
   describe 'with expiration' do
     {
       :incrby      => 'somekey',
@@ -1073,6 +1092,11 @@ describe Redis::Set do
   it "should respond to #to_json" do
     @set_1 << 'a'
     JSON.parse(@set_1.to_json)['value'].should == ['a']
+  end
+
+  it "should respond to #as_json" do
+    @set_1 << 'a'
+    @set_1.as_json['value'].should == ['a']
   end
 
   describe "with expiration" do
@@ -1352,6 +1376,11 @@ describe Redis::SortedSet do
   it "should respond to #to_json" do
     @set['val'] = 1
     JSON.parse(@set.to_json)['value'].should == ['val']
+  end
+
+  it "should respond to #as_json" do
+    @set['val'] = 1
+    @set.as_json['value'].should == ['val']
   end
 
   describe "with expiration" do

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -337,6 +337,17 @@ describe Redis::List do
       @list.redis.del('spec/list2')
     end
 
+    it "responds to #value" do
+      @list << 'a'
+      @list.value.should == @list.get
+      @list.value.should == ['a']
+    end
+
+    it "should support to_json" do
+      @list << 'a'
+      JSON.parse(@list.to_json)['value'].should == ['a']
+    end
+
     after do
       @list.clear
     end
@@ -397,7 +408,6 @@ describe Redis::List do
       @list.ttl.should <= 10
     end
   end
-
 end
 
 describe Redis::Counter do
@@ -465,6 +475,11 @@ describe Redis::Counter do
       end
     @updated.should == 'yep'
     @counter.should == 2
+  end
+
+  it "should support #to_json" do
+    @counter.increment
+    JSON.parse(@counter.to_json)['value'].should == 1
   end
 
   describe 'with expiration' do
@@ -606,6 +621,10 @@ describe Redis::Lock do
 
     # lock value should still be set since the lock was held for more than the expiry
     REDIS_HANDLE.get("test_lock").should.not.be.nil
+  end
+
+  it "should respond to #to_json" do
+    Redis::Lock.new(:test_lock).to_json.should.be.kind_of(String)
   end
 end
 
@@ -828,6 +847,17 @@ describe Redis::HashKey do
     block.should == "oops: missing_key"
   end
 
+  it "should respond to #value" do
+    @hash['abc'] = "123"
+    @hash.value.should == @hash.all
+    @hash.value.should == { "abc" => "123" }
+  end
+
+  it "should respond to #to_json" do
+    @hash['abc'] = "123"
+    JSON.parse(@hash.to_json)['value'].should == { "abc" => "123" }
+  end
+
   describe 'with expiration' do
     {
       :incrby      => 'somekey',
@@ -1032,6 +1062,17 @@ describe Redis::Set do
     @set_1.redis.del val1.key
     @set_1.redis.del val2.key
     @set_1.redis.del SORT_STORE[:store]
+  end
+
+  it "should respond to #value" do
+    @set_1 << 'a'
+    @set_1.value.should == @set_1.members
+    @set_1.value.should == ['a']
+  end
+
+  it "should respond to #to_json" do
+    @set_1 << 'a'
+    JSON.parse(@set_1.to_json)['value'].should == ['a']
   end
 
   describe "with expiration" do
@@ -1300,6 +1341,17 @@ describe Redis::SortedSet do
     @set['val'] = 1
     @set.ttl.should > 0
     @set.ttl.should <= 10
+  end
+
+  it "should respond to #value" do
+    @set['val'] = 1
+    @set.value.should == @set.members
+    @set.value.should == ['val']
+  end
+
+  it "should respond to #to_json" do
+    @set['val'] = 1
+    JSON.parse(@set.to_json)['value'].should == ['val']
   end
 
   describe "with expiration" do

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -194,7 +194,6 @@ describe Redis::Objects do
     @roster.contact_information['updated_at'].class.should == Time
   end
 
-
   it "should create counter accessors" do
     [:available_slots, :pitchers, :basic].each do |m|
        @roster.respond_to?(m).should == true
@@ -877,6 +876,13 @@ describe Redis::Objects do
     @custom_method_roster.basic.reset.should.be.true
     @custom_method_roster.basic.should == 0
     @custom_method_roster.basic.should.be.kind_of(Redis::Counter)
+  end
+
+  it "should respond to #to_json" do
+    @roster = Roster.new
+    @roster.player_totals.increment
+    json = JSON.parse(@roster.player_totals.to_json)
+    json['value'].should == 1
   end
 
   it "should persist object with custom id field name" do


### PR DESCRIPTION
Fixes #134 

I was able to reproduce the blocking call to `Redis::BaseObject#to_json` in tests. The fix proposed here is to implement the `to_json` method of `Redis::BaseObject` to override the `ActiveSupport` behavior which would attempt to pass all instance variable, including the entire `Redis` connection, to json.

The change also adds `Redis::BaseObject#value` to all remaining subclasses in order to provide a common interface to returning the 'logical' ruby object represented by each corresponding wrapper. Happy to take suggestions on other names for this method.

Note, this will blow up if used in an environment where `Hash#to_json` is not defined, but then again, that would have resulted in a similar `NoMethodError` anyways.