### PR TITLE
Add delete whole object method

### DIFF
--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -173,6 +173,10 @@ class Redis
       def redis()         self.class.redis end
       def redis_objects() self.class.redis_objects end
 
+      def delete!
+        redis.del(redis_objects.keys.map { |k| send(k) }.reject(&:nil?).map { |obj| obj.key })
+      end
+
       def redis_options(name) #:nodoc:
         return self.class.redis_options(name)
       end

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -986,4 +986,10 @@ describe Redis::Objects do
     @roster.sorted_set_with_expireat.ttl.should > 0
     @roster.sorted_set_with_expireat.ttl.should <= 10
   end
+
+  it "should allow deleting the entire object" do
+    @roster.redis.keys.select { |key| key.match(/^roster:/)}.count.should > 0
+    @roster.delete!.should > 0
+    @roster.redis.keys.select { |key| key.match(/^roster:/)}.count.should == 0
+  end
 end


### PR DESCRIPTION
As a first attempt to add a feature to this great project, I added a method to Redis::Objects that allows an instance to delete itself.

Instead of a user having to go through each object themselves and deleting each piece, this deletes the whole object for you.

Also added a test for the method.