### PR TITLE
Reduce query to Redis.

### DIFF
--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -131,7 +131,7 @@ class Redis
     def bulk_get(*fields)
       hsh = {}
       get_fields = *fields.flatten
-      get_fields << nil if get_fields.empty?
+      return hsh if get_fields.empty?
       res = redis.hmget(key, get_fields)
       fields.each do |k|
         hsh[k] = unmarshal(res.shift, options[:marshal_keys][k])
@@ -143,7 +143,7 @@ class Redis
     # Values are returned in a collection in the same order than their keys in *keys Redis: HMGET
     def bulk_values(*keys)
       get_keys = *keys.flatten
-      get_keys << nil if get_keys.empty?
+      return [] if get_keys.empty?
       res = redis.hmget(key, get_keys)
       keys.inject([]){|collection, k| collection << unmarshal(res.shift, options[:marshal_keys][k])}
     end

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -891,6 +891,14 @@ describe Redis::HashKey do
     @hash.as_json['value'].should == { "abc" => "123" }
   end
 
+  it "should return empty object with bulk_get and bulk_value" do
+    h = @hash.bulk_get
+    h.should == {}
+
+    v = @hash.bulk_values
+    v.should == []
+  end
+
   describe 'with expiration' do
     {
       :incrby      => 'somekey',


### PR DESCRIPTION
Don't query to Redis if #bulk_get/#bulk_values arguments is empty.