### PR TITLE
Allow to set proc for expireat

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,15 @@ value :value_with_expiration, :expiration => 1.hour
 value :value_with_expireat, :expireat => Time.now + 1.hour
 ~~~
 
+:warning: `expireat` is evaluated at class load time.
+In this example, it will be one hour after evaluating class, not after one hour after setting value.
+
+If you want to expire one hour after setting the value. please use `lambda`.
+
+~~~ruby
+value :value_with_expireat, :expireat => lambda { Time.now + 1.hour }
+~~~
+
 Author
 =======
 Copyright (c) 2009-2013 [Nate Wiger](http://nateware.com).  All Rights Reserved.

--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -18,7 +18,9 @@ class Redis
       if !@options[:expiration].nil?
         redis.expire(@key, @options[:expiration]) if redis.ttl(@key) < 0
       elsif !@options[:expireat].nil?
-        redis.expireat(@key, @options[:expireat].to_i) if redis.ttl(@key) < 0
+        expireat = @options[:expireat]
+        at = expireat.respond_to?(:call) ? expireat.call.to_i : expireat.to_i
+        redis.expireat(@key, at) if redis.ttl(@key) < 0
       end
     end
 

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -47,6 +47,8 @@ class Roster
   sorted_set :sorted_set_with_expiration,:expiration => 10
   sorted_set :sorted_set_with_expireat, :expireat => Time.now + 10.seconds
 
+  value :value_with_expireat_with_lambda, :expireat => lambda { Time.now + 10.seconds }
+
   def initialize(id=1) @id = id end
   def id; @id; end
   def username; "user#{id}"; end
@@ -991,6 +993,19 @@ describe Redis::Objects do
     @roster.sorted_set_with_expireat[:foo] = 1
     @roster.sorted_set_with_expireat.ttl.should > 0
     @roster.sorted_set_with_expireat.ttl.should <= 10
+  end
+
+  it "should set expiration when expireat option assigned with lambda" do
+    travel(1.minute) do
+      # non-proc expireat is not affected by time travel
+      @roster.value_with_expireat.value = 'val'
+      @roster.value_with_expireat.ttl.should > 0
+      @roster.value_with_expireat.ttl.should <= 10
+
+      @roster.value_with_expireat_with_lambda.value = 'val'
+      @roster.value_with_expireat_with_lambda.ttl.should > 60
+      @roster.value_with_expireat_with_lambda.ttl.should <= 70
+    end
   end
 
   it "should allow deleting the entire object" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,9 @@ if $0 =~ /\brspec$/
   raise "\n===\nThese tests are in bacon, not rspec.  Try: bacon #{ARGV * ' '}\n===\n"
 end
 
+require "active_support/testing/time_helpers"
+include ActiveSupport::Testing::TimeHelpers
+
 REDIS_CLASS_NAMES = [:Counter, :HashKey, :List, :Lock, :Set, :SortedSet, :Value]
 
 UNIONSTORE_KEY = 'test:unionstore'


### PR DESCRIPTION
There is a trap in the `expireat` example in the in the README.

```ruby
value :value_with_expireat, :expireat => Time.now + 1.hour
```

`expireat` is evaluated at class load time.
In this example, it will be one hour after evaluating class,
not after one hour after setting value.

If you want to expire one hour after setting the value,
`expireat` can not be satisfied that use case.

So add expireat implementation with proc.

```ruby
value :value_with_expireat, :expireat => lambda { Time.now + 1.hour }
```

If can set proc, `expireat` will be used more flexibly.

For example, if want to expire at 0:00 am every day,
It can be written as follows.

```ruby
value :value_with_expireat, expireat: -> { 1.day.since.midnight }
```

This case can not be written in `expiration`.