### PR TITLE
support redis 4.0.0

### DIFF
--- a/redis-objects.gemspec
+++ b/redis-objects.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Only fix this one version or else tests break
-  spec.add_dependency "redis", "~> 3.3"
+  spec.add_dependency "redis", ">= 3.3", "< 5.0"
 
   # Ignore gemspec warnings on these.  Trying to fix them to versions breaks TravisCI
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
delete redis version lock from redis-namespace 1.6
So we can remove redis version lock and use redis gem 4.0.0 :)