### PR TITLE
Make Redis::Objects.connection thread-safe

### DIFF
--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -61,10 +61,11 @@ class Redis
 
     class << self
       def redis=(conn)
-        @redis = Objects::ConnectionPoolProxy.proxy_if_needed(conn)
+        Thread.current[:__redis_objects_redis] = Objects::ConnectionPoolProxy.proxy_if_needed(conn)
       end
+
       def redis
-        @redis || $redis || Redis.current ||
+        Thread.current[:__redis_objects_redis] || $redis || Redis.current ||
           raise(NotConnected, "Redis::Objects.redis not set to a Redis.new connection")
       end
 
@@ -90,11 +91,11 @@ class Redis
     module ClassMethods
       # Enable per-class connections (eg, User and Post can use diff redis-server)
       def redis=(conn)
-        @redis = Objects::ConnectionPoolProxy.proxy_if_needed(conn)
+        Thread.current[:__redis_objects_redis] = Objects::ConnectionPoolProxy.proxy_if_needed(conn)
       end
 
       def redis
-        @redis || Objects.redis
+        Thread.current[:__redis_objects_redis] || Objects.redis
       end
 
       # Internal list of objects

--- a/spec/redis_objects_conn_spec.rb
+++ b/spec/redis_objects_conn_spec.rb
@@ -41,6 +41,21 @@ describe 'Connection tests' do
     obj.default_redis_value.clear
   end
 
+  it "should be thread-safe when setting Redis::Objects.redis connection" do
+    Redis::Objects.redis = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 23)
+
+    thr = Thread.new do
+      Redis::Objects.redis = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 24)
+      Redis::Objects.redis.connection[:id].ends_with?("/24").should == true
+    end
+
+    Redis::Objects.redis.connection[:id].ends_with?("/23").should == true
+
+    thr.join
+
+    Redis::Objects.redis.connection[:id].ends_with?("/23").should == true
+  end
+
   it "should support mget" do
     class CustomConnectionObject
       include Redis::Objects


### PR DESCRIPTION
This change ensures that using `Redis::Objects.connection` is thread-safe, which will allow users to set this dynamically in threaded environments, like Puma or Sidekiq.  

We need this at ConvertKit because we're in the middle of a migration from Heroku RedisLabs to our own hand-rolled Redis in EC2, and we're doing this per-user.  This requires us to set the connection on a per-request basis, and my change will make this thread-safe.

Note that servers like Puma re-use threads, so in its current form, it will require the user to clear `Redis::Objects.connection` at the end of a request to avoid unwanted surprises.