### PR TITLE
Allow compression of value stored in Redis::Value to save memory on R…

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,18 @@ Complex data is no problem with :marshal => true:
 puts @newest.value['username']
 ~~~
 
+Compress data to save memory usage on Redis with :compress => true:
+
+~~~ruby
+@account = Account.create!(params[:account])
+@marshaled_value = Redis::Value.new('marshaled', :marshal => true, :compress => true)
+@marshaled_value.value = @account.attributes
+@unmarshaled_value = Redis::Value.new('unmarshaled', :compress => true)
+@unmarshaled_value = 'Really Long String'
+puts @marshaled_value.value['username']
+puts @unmarshaled_value.value
+~~~
+
 Lists
 -----
 Lists work just like Ruby arrays:

--- a/lib/redis/value.rb
+++ b/lib/redis/value.rb
@@ -34,7 +34,7 @@ class Redis
 
     def marshal(value, *args)
       if !value.nil? && options[:compress]
-        deflate(super)
+        compress(super)
       else
         super
       end
@@ -42,17 +42,17 @@ class Redis
 
     def unmarshal(value, *args)
       if !value.nil? && options[:compress]
-        super(inflate(value), *args)
+        super(decompress(value), *args)
       else
         super
       end
     end
 
-    def inflate(value)
+    def decompress(value)
       Zlib::Inflate.inflate(value)
     end
 
-    def deflate(value)
+    def compress(value)
       Zlib::Deflate.deflate(value)
     end
 

--- a/lib/redis/value.rb
+++ b/lib/redis/value.rb
@@ -1,4 +1,5 @@
 require File.dirname(__FILE__) + '/base_object'
+require 'zlib'
 
 class Redis
   #
@@ -30,6 +31,30 @@ class Redis
       end
     end
     alias_method :get, :value
+
+    def marshal(value, *args)
+      if !value.nil? && options[:compress]
+        deflate(super)
+      else
+        super
+      end
+    end
+
+    def unmarshal(value, *args)
+      if !value.nil? && options[:compress]
+        super(inflate(value), *args)
+      else
+        super
+      end
+    end
+
+    def inflate(value)
+      Zlib::Inflate.inflate(value)
+    end
+
+    def deflate(value)
+      Zlib::Deflate.deflate(value)
+    end
 
     def inspect
       "#<Redis::Value #{value.inspect}>"

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -19,6 +19,28 @@ describe Redis::Value do
     @value.value.should == false
   end
 
+  it "should compress non marshaled values" do
+    @value = Redis::Value.new('spec/value', compress: true)
+    @value.value = 'Trevor Hoffman'
+    @value.value.should == 'Trevor Hoffman'
+    @value.redis.get(@value.key).should.not == 'Trevor Hoffman'
+    @value.value = nil
+    @value.value.should == nil
+    @value.value = ''
+    @value.value.should == ''
+  end
+
+  it "should compress marshaled values" do
+    @value = Redis::Value.new('spec/value', marshal: true, compress: true)
+    @value.value = 'Trevor Hoffman'
+    @value.value.should == 'Trevor Hoffman'
+    @value.redis.get(@value.key).should.not == Marshal.dump('Trevor Hoffman')
+    @value.value = nil
+    @value.value.should == nil
+    @value.value = ''
+    @value.value.should == ''
+  end
+
   it "should handle simple values" do
     @value.should == nil
     @value.value = 'Trevor Hoffman'


### PR DESCRIPTION
…edis server

This pull requests allows developers to compress the value stored in a `Redis::Value` object by simply specifying `:compress => true` as an option. And it works with both marshaled and raw values. In our use case we were storing large strings in Redis. After compression we saw 10x improvement in bytes used to store strings in Redis. There are no external dependencies for compression since we are using Ruby standard library `Zlib`. There will be overhead to compress and decompress, but we found it to be minimal and worth it for the amount of space saved.