### PR TITLE
Fix set operation methods on SortedSets

### DIFF
--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -211,7 +211,7 @@ class Redis
       result = nil
       temp_key = :"#{key}:intersection:#{Time.current.to_i + rand}"
 
-      redis.pipelined do
+      redis.multi do
         interstore(temp_key, *sets)
         redis.expire(temp_key, 1)
 
@@ -248,7 +248,7 @@ class Redis
       result = nil
       temp_key = :"#{key}:union:#{Time.current.to_i + rand}"
 
-      redis.pipelined do
+      redis.multi do
         unionstore(temp_key, *sets)
         redis.expire(temp_key, 1)
 

--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -8,7 +8,6 @@ class Redis
     # require 'enumerator'
     # include Enumerable
     require 'redis/helpers/core_commands'
-    require 'securerandom'
     include Redis::Helpers::CoreCommands
 
     attr_reader :key, :options
@@ -210,7 +209,7 @@ class Redis
     # Redis: SINTER
     def intersection(*sets)
       result = nil
-      temp_key = :"#{key}:intersection:#{SecureRandom.hex(2)}"
+      temp_key = :"#{key}:intersection:#{Time.current.to_i + rand}"
 
       redis.pipelined do
         interstore(temp_key, *sets)
@@ -247,7 +246,7 @@ class Redis
     # Redis: SUNION
     def union(*sets)
       result = nil
-      temp_key = :"#{key}:union:#{SecureRandom.hex(2)}"
+      temp_key = :"#{key}:union:#{Time.current.to_i + rand}"
 
       redis.pipelined do
         unionstore(temp_key, *sets)

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -1316,6 +1316,8 @@ describe Redis::SortedSet do
     @set_2.add('c', 1)
     @set_2.add('d', 0)
 
+    @set_1.union(@set_2).should == ['d', 'a', 'c', 'b']
+
     @set_1.unionstore(@set.key, @set_2)
     # @set is now: [[d, 0], [a, 1], [c, 4], [b, 6]]
     @set.members.should == ['d', 'a', 'c', 'b']
@@ -1354,6 +1356,8 @@ describe Redis::SortedSet do
     @set_2.add('b', 2)
     @set_2.add('c', 1)
     @set_2.add('d', 0)
+
+    @set_1.intersection(@set_2).should == ['c', 'b']
 
     @set_1.interstore(@set.key, @set_2)
     # @set is now: [[c, 4], [b, 6]]


### PR DESCRIPTION
This pull requests addresses the issue: https://github.com/nateware/redis-objects/issues/221.

Redis does not support `zintersection`, `zunion` or `zdiff` commands for Sorted Set datatype. We can implement `intersection` and `union` pretty easily, in redis-objects, using a temp key to to store results of `zinterstore` and `zunionstore` respectively and returning value at key. This is what I have done below. I also removed the `difference` and `diffstore` methods since there are no diff commands for Sorted Sets in Redis (and current implementation is broken anyways). Essentially this makes `intersection` and `union` a way of getting results while storing data in Redis for only a short period, whereas `interstore` and `unionstore` will create new key that will remain in Redis unless modified by user (e.g. deleted or set to expire).