### PR TITLE
Optimise lock

### DIFF
--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -33,30 +33,16 @@ class Redis
     # Get the lock and execute the code block. Any other code that needs the lock
     # (on any server) will spin waiting for the lock up to the :timeout
     # that was specified when the lock was defined.
-    def lock(&block)
-      expiration = nil
+    def lock
+      raise ArgumentError, 'Block not given' unless block_given?
+      expiration = generate_expiration
+      end_time = nil
       try_until_timeout do
-        expiration = generate_expiration
-        # Use the expiration as the value of the lock.
-        break if redis.setnx(key, expiration)
-
-        # Lock is being held.  Now check to see if it's expired (if we're using
-        # lock expiration).
-        # See "Handling Deadlocks" section on http://redis.io/commands/setnx
-        if !@options[:expiration].nil?
-          old_expiration = redis.get(key).to_f
-
-          if old_expiration < Time.now.to_f
-            # If it's expired, use GETSET to update it.
-            expiration = generate_expiration
-            old_expiration = redis.getset(key, expiration).to_f
-
-            # Since GETSET returns the old value of the lock, if the old expiration
-            # is still in the past, we know no one else has expired the locked
-            # and we now have it.
-            break if old_expiration < Time.now.to_f
-          end
-        end
+        end_time = Time.now.to_i + expiration
+        # Set a NX record and expiration in one request.
+        # Empty value because the presence of it is enough to lock
+        # `px` only except an Integer in millisecond
+        break if redis.set(key, nil, px: expiration, nx: true)
       end
       begin
         yield
@@ -66,14 +52,15 @@ class Redis
         # it's not safe for us to remove it.  Check how much time has passed since we
         # wrote the lock key and only delete it if it hasn't expired (or we're not using
         # lock expiration)
-        if @options[:expiration].nil? || expiration > Time.now.to_f
+        if @options[:expiration].nil? || end_time > Time.now.to_f
           redis.del(key)
         end
       end
     end
 
+    # Return expiration in milliseconds
     def generate_expiration
-      @options[:expiration].nil? ? 1 : (Time.now + @options[:expiration].to_f + 1).to_f
+      ((@options[:expiration].nil? ? 1 : @options[:expiration].to_f) * 1000).to_i
     end
 
     private

--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -39,7 +39,7 @@ class Redis
       end_time = nil
       try_until_timeout do
         end_time = Time.now.to_i + expiration
-        # Set a NX record and expiration in one request.
+        # Set a NX record and use the Redis expiration mechanism.
         # Empty value because the presence of it is enough to lock
         # `px` only except an Integer in millisecond
         break if redis.set(key, nil, px: expiration, nx: true)

--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -636,6 +636,26 @@ describe Redis::Lock do
   it "should respond to #as_json" do
     Redis::Lock.new(:test_lock).as_json.should.be.kind_of(Hash)
   end
+
+  it "should deal with old lock format" do
+    expiry = 15
+    lock = Redis::Lock.new(:test_lock, expiration: expiry, timeout: 0.1)
+
+    # create a fake lock in the past
+    REDIS_HANDLE.set("test_lock", (Time.now - expiry).to_f)
+
+    gotit = false
+    lock.lock do
+      gotit = true
+    end
+
+    # should have the lock
+    gotit.should.be.true
+
+    # lock value should be unset
+    REDIS_HANDLE.get("test_lock").should.be.nil
+  end
+
 end
 
 describe Redis::HashKey do


### PR DESCRIPTION
Use the Redis expiration mechanism.
This will avoid extra requests to Redis to check the expiration set as value.

Extra requests still made to keep the backward compatibility.
We can remove the backward compatibility code at the next major version release and will fix #226.