### PR TITLE
Add expiration in seconds to obtain end_time

### DIFF
--- a/spec/redis_objects_instance_spec.rb
+++ b/spec/redis_objects_instance_spec.rb
@@ -626,7 +626,28 @@ describe Redis::Lock do
     end
 
     # lock value should still be set since the lock was held for more than the expiry
-    REDIS_HANDLE.get("test_lock").should.be.nil
+    REDIS_HANDLE.exists("test_lock").should.be.false
+  end
+
+  it "should manually delete the key if finished before expiration" do
+    lock = Redis::Lock.new(:test_lock, :expiration => 0.2)
+
+    lock.lock do
+      sleep 0.1
+    end
+
+    REDIS_HANDLE.exists("test_lock").should.be.false
+  end
+
+  it "should not manually delete the key if finished after expiration" do
+    lock = Redis::Lock.new(:test_lock, :expiration => 0.1)
+
+    lock.lock do
+      sleep 0.2 # expired
+      REDIS_HANDLE.set("test_lock", "foo")
+    end
+
+    REDIS_HANDLE.get("test_lock").should == "foo"
   end
 
   it "should respond to #to_json" do


### PR DESCRIPTION
Fixes #234 

### Changes
- Uses the generated expiration in seconds (as a Float) to set `update_time`.
- Adds test coverage for described issue

### How to test
1. Run `rake test`
1. Expect all tests to pass
1. Reset the `lock.rb` file to master
1. Rerun tests
1. Expect [this test](https://github.com/nateware/redis-objects/compare/master...johnc219:fix/end-time-expiration?expand=1#diff-0115af38aafc654776c8af9100889aafR642) to fail
