### PR TITLE
DRY up objects

### DIFF
--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -1,6 +1,8 @@
 class Redis
   # Defines base functionality for all redis-objects.
   class BaseObject
+    attr_reader :key, :options
+
     def initialize(key, *args)
       @key     = key.is_a?(Array) ? key.flatten.join(':') : key
       @options = args.last.is_a?(Hash) ? args.pop : {}

--- a/lib/redis/base_object.rb
+++ b/lib/redis/base_object.rb
@@ -1,6 +1,10 @@
+require 'redis/helpers/core_commands'
+
 class Redis
   # Defines base functionality for all redis-objects.
   class BaseObject
+    include Redis::Helpers::CoreCommands
+
     attr_reader :key, :options
 
     def initialize(key, *args)

--- a/lib/redis/counter.rb
+++ b/lib/redis/counter.rb
@@ -12,7 +12,6 @@ class Redis
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
-    attr_reader :key, :options
     def initialize(key, *args)
       super(key, *args)
       @options[:start] ||= @options[:default] || 0

--- a/lib/redis/counter.rb
+++ b/lib/redis/counter.rb
@@ -9,9 +9,6 @@ class Redis
   # class to define a counter.
   #
   class Counter < BaseObject
-    require 'redis/helpers/core_commands'
-    include Redis::Helpers::CoreCommands
-
     def initialize(key, *args)
       super(key, *args)
       @options[:start] ||= @options[:default] || 0

--- a/lib/redis/enumerable_object.rb
+++ b/lib/redis/enumerable_object.rb
@@ -1,0 +1,28 @@
+require File.dirname(__FILE__) + '/base_object'
+
+class Redis
+  #
+  # Class representing a Redis enumerable type (list, set, sorted set, or hash).
+  #
+  class EnumerableObject < BaseObject
+    include Enumerable
+
+    # Iterate through each member. Redis::Objects mixes in Enumerable,
+    # so you can also use familiar methods like +collect+, +detect+, and so forth.
+    def each(&block)
+      value.each(&block)
+    end
+
+    def sort(options={})
+      return super() if block_given?
+      options[:order] = "asc alpha" if options.keys.count == 0  # compat with Ruby
+      val = redis.sort(key, options)
+      val.is_a?(Array) ? val.map{|v| unmarshal(v)} : val
+    end
+
+    # ActiveSupport's core extension `Enumerable#as_json` implementation is incompatible with ours.
+    def as_json(*)
+      to_hash
+    end
+  end
+end

--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -10,7 +10,6 @@ class Redis
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
-    attr_reader :key, :options
     def initialize(key, *args)
       super
       @options[:marshal_keys] ||= {}

--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -1,12 +1,10 @@
-require File.dirname(__FILE__) + '/base_object'
+require File.dirname(__FILE__) + '/enumerable_object'
 
 class Redis
   #
   # Class representing a Redis hash.
   #
-  class HashKey < BaseObject
-    require 'enumerator'
-    include Enumerable
+  class HashKey < EnumerableObject
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
@@ -72,11 +70,6 @@ class Redis
     end
     alias_method :clone, :all
     alias_method :value, :all
-
-    # Enumerate through all fields. Redis: HGETALL
-    def each(&block)
-      all.each(&block)
-    end
 
     # Enumerate through each keys. Redis: HKEYS
     def each_key(&block)
@@ -181,10 +174,6 @@ class Redis
     # Decrement value by float at field. Redis: HINCRBYFLOAT
     def decrbyfloat(field, by=1.0)
       incrbyfloat(field, -by)
-    end
-
-    def as_json(*)
-      to_hash
     end
   end
 end

--- a/lib/redis/hash_key.rb
+++ b/lib/redis/hash_key.rb
@@ -5,9 +5,6 @@ class Redis
   # Class representing a Redis hash.
   #
   class HashKey < EnumerableObject
-    require 'redis/helpers/core_commands'
-    include Redis::Helpers::CoreCommands
-
     def initialize(key, *args)
       super
       @options[:marshal_keys] ||= {}
@@ -91,11 +88,6 @@ class Redis
     # Returns true if dict is empty
     def empty?
       true if size == 0
-    end
-
-    # Clears the dict of all keys/values. Redis: DEL
-    def clear
-      redis.del(key)
     end
 
     # Set keys in bulk, takes a hash of field/values {'field1' => 'val1'}. Redis: HMSET

--- a/lib/redis/helpers/core_commands.rb
+++ b/lib/redis/helpers/core_commands.rb
@@ -50,12 +50,6 @@ class Redis
         redis.move key, dbindex
       end
 
-      def sort(options={})
-        options[:order] = "asc alpha" if options.keys.count == 0  # compat with Ruby
-        val = redis.sort(key, options)
-        val.is_a?(Array) ? val.map{|v| unmarshal(v)} : val
-      end
-
       def marshal(value, domarshal=false)
         if options[:marshal] || domarshal
           Marshal.dump(value)

--- a/lib/redis/helpers/core_commands.rb
+++ b/lib/redis/helpers/core_commands.rb
@@ -6,6 +6,7 @@ class Redis
         redis.exists key
       end
       
+      # Delete key. Redis: DEL
       def delete
         redis.del key
       end

--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -1,13 +1,11 @@
-require File.dirname(__FILE__) + '/base_object'
+require File.dirname(__FILE__) + '/enumerable_object'
 
 class Redis
   #
   # Class representing a Redis list.  Instances of Redis::List are designed to
   # behave as much like Ruby arrays as possible.
   #
-  class List < BaseObject
-    require 'enumerator'
-    include Enumerable
+  class List < EnumerableObject
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
@@ -121,12 +119,6 @@ class Redis
       redis.lrem(key, count, marshal(name))  # weird api
     end
 
-    # Iterate through each member of the set.  Redis::Objects mixes in Enumerable,
-    # so you can also use familiar methods like +collect+, +detect+, and so forth.
-    def each(&block)
-      values.each(&block)
-    end
-
     # Return a range of values from +start_index+ to +end_index+.  Can also use
     # the familiar list[start,end] Ruby syntax. Redis: LRANGE
     def range(start_index, end_index)
@@ -166,10 +158,6 @@ class Redis
 
     def to_s
       values.join(', ')
-    end
-
-    def as_json(*)
-      to_hash
     end
   end
 end

--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -6,9 +6,6 @@ class Redis
   # behave as much like Ruby arrays as possible.
   #
   class List < EnumerableObject
-    require 'redis/helpers/core_commands'
-    include Redis::Helpers::CoreCommands
-
     # Works like push.  Can chain together: list << 'a' << 'b'
     def <<(value)
       push(value) # marshal in push()

--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -11,8 +11,6 @@ class Redis
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
-    attr_reader :key, :options
-
     # Works like push.  Can chain together: list << 'a' << 'b'
     def <<(value)
       push(value) # marshal in push()

--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -10,8 +10,6 @@ class Redis
   #
   class Lock < BaseObject
     class LockTimeout < StandardError; end #:nodoc:
-
-    attr_reader :key, :options
     def initialize(key, *args)
       super(key, *args)
       @options[:timeout] ||= 5

--- a/lib/redis/lock.rb
+++ b/lib/redis/lock.rb
@@ -10,19 +10,13 @@ class Redis
   #
   class Lock < BaseObject
     class LockTimeout < StandardError; end #:nodoc:
+
     def initialize(key, *args)
       super(key, *args)
       @options[:timeout] ||= 5
       @options[:init] = false if @options[:init].nil? # default :init to false
       redis.setnx(key, @options[:start]) unless @options[:start] == 0 || @options[:init] === false
     end
-
-    # Clear the lock.  Should only be needed if there's a server crash
-    # or some other event that gets locks in a stuck state.
-    def clear
-      redis.del(key)
-    end
-    alias_method :delete, :clear
 
     def value
       nil

--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -10,8 +10,6 @@ class Redis
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
-    attr_reader :key, :options
-
     # Works like add.  Can chain together: list << 'a' << 'b'
     def <<(value)
       add(value)

--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -5,9 +5,6 @@ class Redis
   # Class representing a set.
   #
   class Set < EnumerableObject
-    require 'redis/helpers/core_commands'
-    include Redis::Helpers::CoreCommands
-
     # Works like add.  Can chain together: list << 'a' << 'b'
     def <<(value)
       add(value)

--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -1,12 +1,10 @@
-require File.dirname(__FILE__) + '/base_object'
+require File.dirname(__FILE__) + '/enumerable_object'
 
 class Redis
   #
   # Class representing a set.
   #
-  class Set < BaseObject
-    require 'enumerator'
-    include Enumerable
+  class Set < EnumerableObject
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
@@ -70,12 +68,6 @@ class Redis
         end
       end
       res
-    end
-
-    # Iterate through each member of the set.  Redis::Objects mixes in Enumerable,
-    # so you can also use familiar methods like +collect+, +detect+, and so forth.
-    def each(&block)
-      members.each(&block)
     end
 
     # Return the intersection with another set.  Can pass it either another set
@@ -181,10 +173,6 @@ class Redis
 
     def to_s
       members.join(', ')
-    end
-
-    def as_json(*)
-      to_hash
     end
 
     private

--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -5,9 +5,6 @@ class Redis
   # Class representing a sorted set.
   #
   class SortedSet < EnumerableObject
-    require 'redis/helpers/core_commands'
-    include Redis::Helpers::CoreCommands
-
     # How to add values using a sorted set.  The key is the member, eg,
     # "Peter", and the value is the score, eg, 163.  So:
     #    num_posts['Peter'] = 163

--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -1,12 +1,10 @@
-require File.dirname(__FILE__) + '/base_object'
+require File.dirname(__FILE__) + '/enumerable_object'
 
 class Redis
   #
   # Class representing a sorted set.
   #
-  class SortedSet < BaseObject
-    # require 'enumerator'
-    # include Enumerable
+  class SortedSet < EnumerableObject
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 

--- a/lib/redis/sorted_set.rb
+++ b/lib/redis/sorted_set.rb
@@ -10,8 +10,6 @@ class Redis
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
-    attr_reader :key, :options
-
     # How to add values using a sorted set.  The key is the member, eg,
     # "Peter", and the value is the score, eg, 163.  So:
     #    num_posts['Peter'] = 163

--- a/lib/redis/value.rb
+++ b/lib/redis/value.rb
@@ -6,9 +6,6 @@ class Redis
   # Class representing a simple value.  You can use standard Ruby operations on it.
   #
   class Value < BaseObject
-    require 'redis/helpers/core_commands'
-    include Redis::Helpers::CoreCommands
-
     def value=(val)
       allow_expiration do
         if val.nil?

--- a/lib/redis/value.rb
+++ b/lib/redis/value.rb
@@ -9,8 +9,6 @@ class Redis
     require 'redis/helpers/core_commands'
     include Redis::Helpers::CoreCommands
 
-    attr_reader :key, :options
-
     def value=(val)
       allow_expiration do
         if val.nil?


### PR DESCRIPTION
* Move `attr_reader`s to `Redis::BaseObject`.
  This allows for easier key customization across all object types.
  ~~~ruby
  class Redis::BaseObject
    module WithCustomKey
      def key
        "prefix_#{super}_suffix"
      end
    end
    prepend WithCustomKey
  end
  ~~~

* Move `Enumerable` functionality to `EnumerableObject`
* Move `CoreCommands` inclusion to `BaseObject`