### PR TITLE
Reduce complexity since `range` never return nil

### DIFF
--- a/lib/redis/list.rb
+++ b/lib/redis/list.rb
@@ -84,8 +84,7 @@ class Redis
 
     # Return all values in the list. Redis: LRANGE(0,-1)
     def values
-      vals = range(0, -1)
-      vals.nil? ? [] : vals
+      range(0, -1)
     end
     alias_method :get, :values
     alias_method :value, :values


### PR DESCRIPTION
The return value of `range` is not possible to be nil.
It calls `.map` on the value of return by `lrange`

https://github.com/nateware/redis-objects/blob/fbe7f7cbe36d14622e17a81b2685939c606bc66c/lib/redis/list.rb#L134-L136