### PR TITLE
Fix #delete!

### DIFF
--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -173,8 +173,15 @@ class Redis
       def redis()         self.class.redis end
       def redis_objects() self.class.redis_objects end
 
-      def delete!
-        redis.del(redis_objects.keys.map { |k| send(k) }.reject(&:nil?).map { |obj| obj.key })
+      def redis_delete_objects
+        redis.del(redis_instance_keys)
+      end
+
+      def redis_instance_keys
+        redis_objects
+          .reject { |_, value| value[:global] }
+          .keys
+          .collect { |name| redis_field_key(name) }
       end
 
       def redis_options(name) #:nodoc:

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -1009,8 +1009,15 @@ describe Redis::Objects do
   end
 
   it "should allow deleting the entire object" do
-    @roster.redis.keys.select { |key| key.match(/^roster:/)}.count.should > 0
-    @roster.delete!.should > 0
-    @roster.redis.keys.select { |key| key.match(/^roster:/)}.count.should == 0
+    (@roster.redis.keys & @roster.redis_instance_keys).count.should > 0
+    @roster.redis_delete_objects.should > 0
+    (@roster.redis.keys & @roster.redis_instance_keys).count.should == 0
+  end
+
+  it "should be able to return all instance keys" do
+    @roster.redis_instance_keys.include?('roster:1:player_stats').should == true
+    @roster.redis_instance_keys.include?('players:my_rank:user1').should == true
+    @roster.redis_instance_keys.include?('roster:1:player_stats').should == true
+    @roster.redis_instance_keys.include?('players:all_stats').should == false
   end
 end


### PR DESCRIPTION
This PR fixes the broken behaviour (and renames) the `#delete!` method.

First of all the `#delete!` method is a terrible name for the method. There's a high risk that it collides with names of other libraries (say soft deletion libraries often used in Rails context). Rails has a `#delete` method on AR-objects that *deletes the record in database*, and normal best practice is to have a bang method that raises exceptions on error. This `#delete!` method does no such thing neither functional or theoretically. It also opens up a can of worms when a developer forgets a `!` in their code..

It smells a lot to have:

```ruby
class User < ActiveRecord::Base
   include Redis::Objects
end

User.first.delete # Deletes record in database, DELETE .. WHERE id = n
User.first.delete! # Deletes Redis objects but doesn't do anything with the record itself.. WTF?
```

Furthermore the current `#delete` method - called on an instance - **also deletes global keys**. This is totally unexpected and probably not what neither the developer or the author of the original method in this library wanted.

Lastly, the current method loops through all defined Redis-objects on an instance to interpolate the keys, making a call to Redis each time fetching the value (and unnecessarily checks for nil values) before deleting. This is not needed and can be made with a less expensive O(n) call to `#del` with the keys.

This PR fixes the issues and adds proper tests.

* Rename #delete! to #redis_delete_objects to be more specific about the behaviour
* Make behaviour actually as expected (eg. not delete global keys!)
* Add #redis_instance_keys which returns interpolated keys 
* Make deletion simpler with just 1 call to Redis