### PR TITLE
Allow spop to return multiple members

### DIFF
--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -27,8 +27,8 @@ class Redis
     end
 
     # Remove and return a random member.  Redis: SPOP
-    def pop
-      unmarshal redis.spop(key)
+    def pop(count = nil)
+      unmarshal redis.spop(key, count)
     end
 
     # return a random member.  Redis: SRANDMEMBER


### PR DESCRIPTION
Redis's SPOP allows for popping multiple members, whereas redis-objects currently does not. This change would allow a count to be passed.