### PR TITLE
Direct setters for lists hashes and sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Familiar Ruby array operations Just Work (TM):
 @team.on_base.shift
 @team.on_base.length  # 1
 @team.on_base.delete('player2')
+@team.on_base = ['player1', 'player2']  # ['player1', 'player2']
 ~~~
 
 Sets work too:
@@ -157,6 +158,15 @@ Sets work too:
   puts player
 end
 player = @team.outfielders.detect{|of| of == 'outfielder2'}
+@team.outfielders = ['outfielder1', 'outfielder3']  # ['outfielder1', 'outfielder3']
+~~~
+
+Hashes work too:
+
+~~~ruby
+@team.pitchers_faced['player1'] = 'pitcher2'
+@team.pitchers_faced['player2'] = 'pitcher1'
+@team.pitchers_faced = { 'player1' => 'pitcher2', 'player2' => 'pitcher1' }
 ~~~
 
 And you can do unions and intersections between objects (kinda cool):

--- a/lib/redis/objects/hashes.rb
+++ b/lib/redis/objects/hashes.rb
@@ -26,6 +26,15 @@ class Redis
                   )
                 )
             end
+
+            define_method(:"#{name}=") do |values|
+              hash_key = public_send(name)
+
+              redis.pipelined do
+                hash_key.clear
+                hash_key.bulk_set(values)
+              end
+            end
           end
 
           if options[:global]

--- a/lib/redis/objects/lists.rb
+++ b/lib/redis/objects/lists.rb
@@ -26,6 +26,15 @@ class Redis
                   )
                 )
             end
+
+            define_method(:"#{name}=") do |values|
+              list = public_send(name)
+
+              redis.pipelined do
+                list.clear
+                list.push(*values)
+              end
+            end
           end
 
           if options[:global]

--- a/lib/redis/objects/sets.rb
+++ b/lib/redis/objects/sets.rb
@@ -26,6 +26,15 @@ class Redis
                   )
                 )
             end
+
+            define_method(:"#{name}=") do |values|
+              set = public_send(name)
+
+              redis.pipelined do
+                set.clear
+                set.merge(*values)
+              end
+            end
           end
 
           if options[:global]

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -162,6 +162,14 @@ describe Redis::Objects do
     @roster.redis.get(k).should == '1'
   end
 
+  it "should be able to directly assign value of hash" do
+    @roster.contact_information['John_Name'] = 'John Doe'
+    @roster.contact_information = { 'John_Phone' => '12345678', 'John_Address' => '321 LANE' }
+    @roster.contact_information['John_Phone'].should == '12345678'
+    @roster.contact_information['John_Address'].should == '321 LANE'
+    @roster.contact_information['John_Name'].should.be.nil
+  end
+
   it "should be able to get/set contact info" do
     @roster.contact_information['John_Phone'] = '123415352'
     @roster.contact_information['John_Address'] = '123 LANE'
@@ -485,6 +493,12 @@ describe Redis::Objects do
     @roster.starting_pitcher.should.be.nil
   end
 
+  it "should be able to directly assign value of list" do
+    @roster.player_stats << 'c'
+    @roster.player_stats = ['a', 'b']
+    @roster.player_stats.get.should == ['a', 'b']
+  end
+
   it "should handle lists of simple values" do
     @roster.player_stats.should.be.empty
     @roster.player_stats << 'a'
@@ -557,6 +571,14 @@ describe Redis::Objects do
     coll.should == ['a','a']
     @roster.player_stats.should == ['a','c','f','j','h','i','a']
     @roster.player_stats.get.should == ['a','c','f','j','h','i','a']
+  end
+
+  it "should be able to directly assign values of set" do
+    @roster.outfielders << 'c'
+    @roster.outfielders = ['a', 'b']
+    @roster.outfielders.member?('a').should.be.true
+    @roster.outfielders.member?('b').should.be.true
+    @roster.outfielders.member?('c').should.be.false
   end
 
   it "should handle sets of simple values" do


### PR DESCRIPTION
This PR adds functionality suggested in https://github.com/nateware/redis-objects/issues/246.

Lists, Sets and Hashes can now be directly assigned

```
class Foo
  include Redis::Objects

  list :my_list
  set :my_set
  hash_key :my_hash
end

foo = Foo.new
foo.my_list = [1, 2, 3]
foo.my_set = [1, 2, 3]
foot.my_hash = { key1: 'value1', key2: 'value2' }
```