### PR TITLE
Removing unused local variable `dir`

### DIFF
--- a/lib/redis/objects.rb
+++ b/lib/redis/objects.rb
@@ -46,8 +46,6 @@ class Redis
   #
   #
   module Objects
-    dir = File.expand_path(__FILE__.sub(/\.rb$/,''))
-
     autoload :Counters,   'redis/objects/counters'
     autoload :Lists,      'redis/objects/lists'
     autoload :Locks,      'redis/objects/locks'


### PR DESCRIPTION
Here's a tiny patch removing an unused variable since 98226b95f35ef455f231692fdb679dfd61200a78.