### PR TITLE
Change Redis#exists to Redis#exists?

### DIFF
--- a/lib/redis/counter.rb
+++ b/lib/redis/counter.rb
@@ -112,7 +112,7 @@ class Redis
     alias_method :to_i, :value
 
     def nil?
-      !redis.exists(key)
+      !redis.exists?(key)
     end
 
     ##

--- a/lib/redis/helpers/core_commands.rb
+++ b/lib/redis/helpers/core_commands.rb
@@ -3,7 +3,7 @@ class Redis
     # These are core commands that all types share (rename, etc)
     module CoreCommands
       def exists?
-        redis.exists key
+        redis.exists? key
       end
 
       # Delete key. Redis: DEL

--- a/redis-objects.gemspec
+++ b/redis-objects.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Only fix this one version or else tests break
-  spec.add_dependency "redis", "~> 4.0"
+  spec.add_dependency "redis", "~> 4.2"
 
   # Ignore gemspec warnings on these.  Trying to fix them to versions breaks TravisCI
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
According to [redis changelog](https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#420):
- `exists` method is going to change its behaviour to return an Integer value instead of Boolean
- `exists?` method was added to get a Boolean if any of the keys exist

So, starting from version 4.2 we can safely use `Redis#exists?` instead of `Redis#exist`

**Changes**
* bump redis version to 4.2
* use redis.exists? instead of redis.exists