### PR TITLE
Fix Redis::Objects::ConnectionPoolProxy #method_missing can pass key arguments

### DIFF
--- a/lib/redis/objects/connection_pool_proxy.rb
+++ b/lib/redis/objects/connection_pool_proxy.rb
@@ -6,8 +6,8 @@ class Redis
         @pool = pool
       end
 
-      def method_missing(name, *args, &block)
-        @pool.with { |x| x.send(name, *args, &block) }
+      def method_missing(name, *args, **kargs, &block)
+        @pool.with { |x| x.send(name, *args, **kargs, &block) }
       end
 
       def respond_to_missing?(name, include_all = false)


### PR DESCRIPTION
Redis::Objects::ConnectionPoolProxy #method_missing can pass key argument For Ruby 3.0 

Related link
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0