### PR TITLE
Let lock to use redis_options method

### DIFF
--- a/lib/redis/objects/locks.rb
+++ b/lib/redis/objects/locks.rb
@@ -25,7 +25,7 @@ class Redis
               instance_variable_get(ivar_name) or
                 instance_variable_set(ivar_name,
                   Redis::Lock.new(
-                    redis_field_key(lock_name), redis_field_redis(lock_name), redis_objects[lock_name.to_sym]
+                    redis_field_key(lock_name), redis_field_redis(lock_name), redis_options(lock_name)
                   )
                 )
             end

--- a/spec/redis_objects_model_spec.rb
+++ b/spec/redis_objects_model_spec.rb
@@ -921,6 +921,15 @@ describe Redis::Objects do
     VanillaRoster.last_player.should.be.kind_of(Redis::Value)
   end
 
+  it "should allow subclass objects to get options from superclass" do
+    @vanilla_roster.available_slots.options[:start].should == 10
+    @vanilla_roster.contact_information.options[:marshal_keys].should == { 'updated_at'=> true }
+    @vanilla_roster.resort_lock.options[:timeout].should == 2
+    @vanilla_roster.starting_pitcher.options[:marshal].should == true
+    @vanilla_roster.player_stats.options[:marshal].should == true
+    @vanilla_roster.outfielders.options[:marshal].should == true
+  end
+
   it "should allow subclass overrides of the same redis object" do
     @roster.basic.should == 0
     @custom_roster.basic.increment.should == 1


### PR DESCRIPTION
I encountered the same issue as https://github.com/nateware/redis-objects/pull/157 solved, but is for `lock` method.
I am not sure why https://github.com/nateware/redis-objects/pull/157 didn't  let `lock` to use `redis_options`, but I think it should be.

This PR introduce `redis_options` on `lock` methods and add some test cases.
P.S. I didn't add test case on `sorted_set` because it didn't have any options yet.
https://github.com/nateware/redis-objects/blob/054c537700e99a27be6b99bfa691351d070dbc5e/spec/redis_objects_model_spec.rb#L6-L16