### PR TITLE
Update warning regarding expiration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,10 +564,10 @@ value :value_with_expiration, :expiration => 1.hour
 value :value_with_expireat, :expireat => lambda { Time.now + 1.hour }
 ~~~
 
-:warning: In the above example, `expiration` is evaluated at class load time.
-In this example, it will be one hour after loading the class, not after one hour
-after setting a value. If you want to expire one hour after setting the value,
-please use `:expireat` with `lambda`.
+:warning: `expireat` is evaluated at class load time.
+If set to a value such as `Time.now + 1.hour`, it will be one hour after loading
+the class, not after one hour after setting a value. If you want to expire one
+hour after setting the value, please use `:expireat` with `lambda`.
 
 Custom serialization
 --------------------


### PR DESCRIPTION
Based on https://github.com/nateware/redis-objects/pull/213 and the comments on https://github.com/nateware/redis-objects/commit/4854553f451c1b983ce620e205c45acea1fefc5b, the current README incorrectly describes an issue with the `expiration` setting when it is actually meant to be describing an issue with the `expireat` setting. This updates the documentation to correctly describe the issue.